### PR TITLE
Fix encodeBase64 URL-safe output

### DIFF
--- a/encodingFunctions/encodeBase64.ts
+++ b/encodingFunctions/encodeBase64.ts
@@ -7,8 +7,12 @@ import { Buffer } from 'buffer';
  * @returns The base64 encoded string.
  */
 export function encodeBase64(str: string): string {
-  return Buffer.from(str).toString('base64');
+  return Buffer.from(str)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
 }
 
 // Example usage:
-// encodeBase64("hello world"); // "aGVsbG8gd29ybGQ="
+// encodeBase64("hello world"); // "aGVsbG8gd29ybGQ"


### PR DESCRIPTION
## Summary
- ensure `encodeBase64` produces URL-safe strings
- update example in JSDoc

## Testing
- `npm test` *(fails: Allure not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686816c23f708325b281bf1a84288069