### PR TITLE
Fix parseQueryString edge cases

### DIFF
--- a/functionsUnittests/utilityFunctions/parseQueryString.test.ts
+++ b/functionsUnittests/utilityFunctions/parseQueryString.test.ts
@@ -1,0 +1,33 @@
+import { parseQueryString } from '../../utilityFunctions/parseQueryString';
+
+describe('parseQueryString', () => {
+  // Test case 1: Parse a basic query string
+  it('1. should parse a basic query string', () => {
+    const queryString = '?name=John&age=30';
+    const result = parseQueryString(queryString);
+    const expected = { name: 'John', age: '30' };
+    expect(result).toEqual(expected);
+  });
+
+  // Test case 2: Handle empty query string
+  it('2. should return an empty object for an empty query string', () => {
+    const queryString = '';
+    const result = parseQueryString(queryString);
+    expect(result).toEqual({});
+  });
+
+  // Test case 3: Handle query string with only a question mark
+  it('3. should return an empty object for a question mark only', () => {
+    const queryString = '?';
+    const result = parseQueryString(queryString);
+    expect(result).toEqual({});
+  });
+
+  // Test case 4: Treat plus signs as spaces
+  it('4. should treat plus signs as spaces when decoding', () => {
+    const queryString = '?name=John+Doe&city=New+York';
+    const result = parseQueryString(queryString);
+    const expected = { name: 'John Doe', city: 'New York' };
+    expect(result).toEqual(expected);
+  });
+});

--- a/utilityFunctions/parseQueryString.ts
+++ b/utilityFunctions/parseQueryString.ts
@@ -5,8 +5,13 @@
  * @returns An object representing the query parameters.
  */
 export function parseQueryString(queryString: string): Record<string, string> {
+  if (!queryString || queryString === '?') {
+    return {};
+  }
+
   return queryString
     .replace(/^\?/, '')
+    .replace(/\+/g, ' ')
     .split('&')
     .reduce(
       (acc, queryParam) => {


### PR DESCRIPTION
## Summary
- return `{}` for empty query strings
- treat `+` as a space when parsing query strings
- add unit tests for the new behavior

## Testing
- `npm run test:local` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868170434248325bc8c21bfc20021d4