### PR TITLE
Fix throttle context preservation

### DIFF
--- a/functionsUnittests/utilityFunctions/throttle.test.ts
+++ b/functionsUnittests/utilityFunctions/throttle.test.ts
@@ -1,0 +1,22 @@
+import { throttle } from '../../utilityFunctions/throttle';
+
+describe('throttle', () => {
+  it('1. should preserve the context for immediate and delayed calls', (done) => {
+    const obj = {
+      count: 0,
+      increment: function () {
+        this.count++;
+      },
+    };
+
+    const throttledIncrement = throttle(obj.increment, 20);
+
+    throttledIncrement.call(obj);
+    throttledIncrement.call(obj);
+
+    setTimeout(() => {
+      expect(obj.count).toBe(2);
+      done();
+    }, 40);
+  });
+});

--- a/utilityFunctions/throttle.ts
+++ b/utilityFunctions/throttle.ts
@@ -12,8 +12,9 @@ export function throttle<T extends (...args: any[]) => void>(
   let lastFunc: NodeJS.Timeout | null;
   let lastRan: number | null = null;
   return function (...args: Parameters<T>) {
+    const context = this;
     if (!lastRan || Date.now() - lastRan >= limit) {
-      func(...args);
+      func.apply(context, args);
       lastRan = Date.now();
     } else {
       if (lastFunc) {
@@ -21,7 +22,7 @@ export function throttle<T extends (...args: any[]) => void>(
       }
       lastFunc = setTimeout(
         () => {
-          func(...args);
+          func.apply(context, args);
         },
         limit - (Date.now() - lastRan),
       );


### PR DESCRIPTION
## Summary
- ensure throttle preserves `this` context using `func.apply`
- add a test verifying that throttled calls keep the context

## Testing
- `npm test` *(fails: Allure is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686817188a208325b0c5acfa24a24664