### PR TITLE
Add more utility tests

### DIFF
--- a/functionsUnittests/utilityFunctions/parseQueryString.test.ts
+++ b/functionsUnittests/utilityFunctions/parseQueryString.test.ts
@@ -30,4 +30,28 @@ describe('parseQueryString', () => {
     const expected = { name: 'John Doe', city: 'New York' };
     expect(result).toEqual(expected);
   });
+
+  // Test case 5: Parse query string without a leading question mark
+  it('5. should parse a query string without a leading question mark', () => {
+    const queryString = 'foo=bar&baz=qux';
+    const result = parseQueryString(queryString);
+    const expected = { foo: 'bar', baz: 'qux' };
+    expect(result).toEqual(expected);
+  });
+
+  // Test case 6: Decode percent-encoded characters
+  it('6. should decode percent-encoded characters', () => {
+    const queryString = '?title=Hello%20World&symbol=%26';
+    const result = parseQueryString(queryString);
+    const expected = { title: 'Hello World', symbol: '&' };
+    expect(result).toEqual(expected);
+  });
+
+  // Test case 7: Handle repeated parameters by keeping the last value
+  it('7. should keep the last value for repeated parameters', () => {
+    const queryString = '?a=1&a=2';
+    const result = parseQueryString(queryString);
+    const expected = { a: '2' };
+    expect(result).toEqual(expected);
+  });
 });

--- a/functionsUnittests/utilityFunctions/throttle.test.ts
+++ b/functionsUnittests/utilityFunctions/throttle.test.ts
@@ -19,4 +19,54 @@ describe('throttle', () => {
       done();
     }, 40);
   });
+
+  // Test case 2: Ensure the function is only called once within the limit
+  it('2. should throttle rapid successive calls', (done) => {
+    const mockFn = jest.fn();
+    const throttled = throttle(mockFn, 30);
+
+    throttled();
+    throttled();
+    throttled();
+
+    // Only the first call should execute immediately
+    expect(mockFn).toHaveBeenCalledTimes(1);
+
+    setTimeout(() => {
+      // After the limit, the function should be called a second time
+      expect(mockFn).toHaveBeenCalledTimes(2);
+      done();
+    }, 50);
+  });
+
+  // Test case 3: Verify arguments from the last call are used
+  it('3. should use the latest arguments for the delayed call', (done) => {
+    const received: number[] = [];
+    const throttled = throttle((val: number) => received.push(val), 20);
+
+    throttled(1);
+    throttled(2);
+
+    setTimeout(() => {
+      expect(received).toEqual([1, 2]);
+      done();
+    }, 40);
+  });
+
+  // Test case 4: Allow calls after the wait period has passed
+  it('4. should execute again after the limit when called later', (done) => {
+    const mockFn = jest.fn();
+    const throttled = throttle(mockFn, 20);
+
+    throttled();
+
+    setTimeout(() => {
+      throttled();
+    }, 30);
+
+    setTimeout(() => {
+      expect(mockFn).toHaveBeenCalledTimes(2);
+      done();
+    }, 60);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `throttle.test.ts` to cover more behaviors
- extend `parseQueryString.test.ts` with additional querystring scenarios

## Testing
- `npm run test:local`

------
https://chatgpt.com/codex/tasks/task_e_686bd019a48483259b86fe7da81e8ca9