### PR TITLE
Add unified JSDoc examples

### DIFF
--- a/dateFunctions/addDays.ts
+++ b/dateFunctions/addDays.ts
@@ -5,6 +5,11 @@
  * @param days - The number of days to add.
  * @returns A new Date object with the days added.
  * @throws Will throw an error if the date is invalid or if days is NaN.
+ *
+ * @example
+ * const today = new Date();
+ * addDays(today, 10); // Adds 10 days to the current date
+ *
  */
 export function addDays(date: Date, days: number): Date {
   if (isNaN(date.getTime())) {
@@ -19,6 +24,3 @@ export function addDays(date: Date, days: number): Date {
   return result;
 }
 
-// Example usage:
-// const today = new Date();
-// addDays(today, 10); // Adds 10 days to the current date

--- a/dateFunctions/addMonths.ts
+++ b/dateFunctions/addMonths.ts
@@ -5,6 +5,11 @@
  * @param months - The number of months to add.
  * @returns A new Date object with the months added.
  * @throws Will throw an error if the date is invalid or if months is NaN.
+ *
+ * @example
+ * const today = new Date();
+ * addMonths(today, 3); // Adds 3 months to the current date
+ *
  */
 export function addMonths(date: Date, months: number): Date {
   if (isNaN(date.getTime())) {
@@ -19,6 +24,3 @@ export function addMonths(date: Date, months: number): Date {
   return result;
 }
 
-// Example usage:
-// const today = new Date();
-// addMonths(today, 3); // Adds 3 months to the current date

--- a/dateFunctions/businessDaysBetween.ts
+++ b/dateFunctions/businessDaysBetween.ts
@@ -5,6 +5,12 @@
  * @param end - The end Date object.
  * @returns The number of business days between the two dates.
  * @throws Will throw an error if the start or end date is invalid.
+ *
+ * @example
+ * const start = new Date('2024-09-01');
+ * const end = new Date('2024-09-30');
+ * businessDaysBetween(start, end); // Number of business days in September 2024
+ *
  */
 export function businessDaysBetween(start: Date, end: Date): number {
   if (isNaN(start.getTime()) || isNaN(end.getTime())) {
@@ -30,7 +36,3 @@ export function businessDaysBetween(start: Date, end: Date): number {
   return count;
 }
 
-// Example usage:
-// const start = new Date('2024-09-01');
-// const end = new Date('2024-09-30');
-// businessDaysBetween(start, end); // Number of business days in September 2024

--- a/dateFunctions/calculateAge.ts
+++ b/dateFunctions/calculateAge.ts
@@ -4,6 +4,11 @@
  * @param dob - The date of birth.
  * @returns The age in years.
  * @throws Will throw an error if the date of birth is invalid.
+ *
+ * @example
+ * const dob = new Date('1990-09-19');
+ * calculateAge(dob); // e.g., 34
+ *
  */
 export function calculateAge(dob: Date): number {
   if (isNaN(dob.getTime())) {
@@ -27,6 +32,3 @@ export function calculateAge(dob: Date): number {
   return age;
 }
 
-// Example usage:
-// const dob = new Date('1990-09-19');
-// calculateAge(dob); // e.g., 34

--- a/dateFunctions/compareDates.ts
+++ b/dateFunctions/compareDates.ts
@@ -5,6 +5,12 @@
  * @param date2 - The second Date object.
  * @returns -1 if date1 is before date2, 1 if date1 is after date2, and 0 if they are the same.
  * @throws Will throw an error if either date is invalid.
+ *
+ * @example
+ * const date1 = new Date('2024-09-19');
+ * const date2 = new Date('2024-09-20');
+ * compareDates(date1, date2); // -1
+ *
  */
 export function compareDates(date1: Date, date2: Date): number {
   if (isNaN(date1.getTime()) || isNaN(date2.getTime())) {
@@ -20,7 +26,3 @@ export function compareDates(date1: Date, date2: Date): number {
   }
 }
 
-// Example usage:
-// const date1 = new Date('2024-09-19');
-// const date2 = new Date('2024-09-20');
-// compareDates(date1, date2); // -1

--- a/dateFunctions/daysBetween.ts
+++ b/dateFunctions/daysBetween.ts
@@ -5,6 +5,12 @@
  * @param date2 - The second Date object.
  * @returns The number of days between the two dates.
  * @throws Will throw an error if either date is invalid or if the first date is later than the second date.
+ *
+ * @example
+ * const startDate = new Date('2024-01-01');
+ * const endDate = new Date('2024-12-31');
+ * daysBetween(startDate, endDate); // 364
+ *
  */
 export function daysBetween(date1: Date, date2: Date): number {
   if (isNaN(date1.getTime()) || isNaN(date2.getTime())) {
@@ -20,7 +26,3 @@ export function daysBetween(date1: Date, date2: Date): number {
   return Math.floor(diffInTime / oneDay);
 }
 
-// Example usage:
-// const startDate = new Date('2024-01-01');
-// const endDate = new Date('2024-12-31');
-// daysBetween(startDate, endDate); // 364

--- a/dateFunctions/daysLeftInYear.ts
+++ b/dateFunctions/daysLeftInYear.ts
@@ -4,6 +4,11 @@
  * @param date - The Date object to calculate the remaining days from.
  * @returns The number of days left in the current year.
  * @throws Will throw an error if the date is invalid.
+ *
+ * @example
+ * const today = new Date();
+ * daysLeftInYear(today); // Number of days left in the year from today
+ *
  */
 export function daysLeftInYear(date: Date): number {
   if (isNaN(date.getTime())) {
@@ -15,6 +20,3 @@ export function daysLeftInYear(date: Date): number {
   return Math.ceil(diffInMs / (1000 * 60 * 60 * 24));
 }
 
-// Example usage:
-// const today = new Date();
-// daysLeftInYear(today); // Number of days left in the year from today

--- a/dateFunctions/formatDate.ts
+++ b/dateFunctions/formatDate.ts
@@ -5,6 +5,11 @@
  * @param format - The format string (e.g., 'YYYY-MM-DD', 'MM/DD/YYYY').
  * @returns The formatted date string.
  * @throws Will throw an error if the date is invalid or if the format string contains unsupported tokens.
+ *
+ * @example
+ * const date = new Date();
+ * formatDate(date, 'YYYY-MM-DD HH:mm:ss'); // e.g., '2024-09-19 15:45:30'
+ *
  */
 export function formatDate(date: Date, format: string): string {
   if (isNaN(date.getTime())) {
@@ -41,6 +46,3 @@ export function formatDate(date: Date, format: string): string {
   return format.replace(/YYYY|MM|DD|HH|mm|ss/g, (matched) => map[matched]);
 }
 
-// Example usage:
-// const date = new Date();
-// formatDate(date, 'YYYY-MM-DD HH:mm:ss'); // e.g., '2024-09-19 15:45:30'

--- a/dateFunctions/getCurrentDateTimeISO.ts
+++ b/dateFunctions/getCurrentDateTimeISO.ts
@@ -2,10 +2,12 @@
  * Gets the current date and time in ISO 8601 format.
  *
  * @returns The current date and time as an ISO string.
+ *
+ * @example
+ * getCurrentDateTimeISO(); // e.g., '2024-09-19T15:45:30.000Z'
+ *
  */
 export function getCurrentDateTimeISO(): string {
   return new Date().toISOString();
 }
 
-// Example usage:
-// getCurrentDateTimeISO(); // e.g., '2024-09-19T15:45:30.000Z'

--- a/dateFunctions/getDateParts.ts
+++ b/dateFunctions/getDateParts.ts
@@ -3,6 +3,11 @@
  *
  * @param date - The Date object to extract parts from.
  * @returns An object containing year, month, day, hours, minutes, and seconds.
+ *
+ * @example
+ * const date = new Date('2024-09-19T15:45:30');
+ * getDateParts(date); // { year: 2024, month: 9, day: 19, hours: 15, minutes: 45, seconds: 30 }
+ *
  */
 export function getDateParts(date: Date): {
   year: number;
@@ -26,6 +31,3 @@ export function getDateParts(date: Date): {
   };
 }
 
-// Example usage:
-// const date = new Date('2024-09-19T15:45:30');
-// getDateParts(date); // { year: 2024, month: 9, day: 19, hours: 15, minutes: 45, seconds: 30 }

--- a/dateFunctions/getDaysInMonth.ts
+++ b/dateFunctions/getDaysInMonth.ts
@@ -4,6 +4,11 @@
  * @param date - The Date object to get the month's day count from.
  * @returns The number of days in the month.
  * @throws Will throw an error if the date is invalid.
+ *
+ * @example
+ * const date = new Date('2024-09-19');
+ * getDaysInMonth(date); // e.g., 30 (for September)
+ *
  */
 export function getDaysInMonth(date: Date): number {
   if (isNaN(date.getTime())) {
@@ -15,6 +20,3 @@ export function getDaysInMonth(date: Date): number {
   return new Date(year, month + 1, 0).getDate();
 }
 
-// Example usage:
-// const date = new Date('2024-09-19');
-// getDaysInMonth(date); // e.g., 30 (for September)

--- a/dateFunctions/getDaysOfWeek.ts
+++ b/dateFunctions/getDaysOfWeek.ts
@@ -2,6 +2,10 @@
  * Gets an array of the days of the week.
  *
  * @returns An array of strings representing the days of the week.
+ *
+ * @example
+ * getDaysOfWeek(); // ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+ *
  */
 export function getDaysOfWeek(): string[] {
   return [
@@ -15,5 +19,3 @@ export function getDaysOfWeek(): string[] {
   ];
 }
 
-// Example usage:
-// getDaysOfWeek(); // ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']

--- a/dateFunctions/getEndOfMonth.ts
+++ b/dateFunctions/getEndOfMonth.ts
@@ -4,6 +4,11 @@
  * @param date - The Date object to get the month's end date from.
  * @returns A new Date object representing the last day of the month.
  * @throws Will throw an error if the date is invalid.
+ *
+ * @example
+ * const date = new Date('2024-09-15');
+ * getEndOfMonth(date); // Gets '2024-09-30'
+ *
  */
 export function getEndOfMonth(date: Date): Date {
   if (isNaN(date.getTime())) {
@@ -14,6 +19,3 @@ export function getEndOfMonth(date: Date): Date {
   return lastDay;
 }
 
-// Example usage:
-// const date = new Date('2024-09-15');
-// getEndOfMonth(date); // Gets '2024-09-30'

--- a/dateFunctions/getEndOfWeek.ts
+++ b/dateFunctions/getEndOfWeek.ts
@@ -5,6 +5,11 @@
  * @param startOfWeek - The start day of the week (0 for Sunday, 1 for Monday, etc.).
  * @returns A new Date object representing the end of the week.
  * @throws Will throw an error if the date is invalid or if the startOfWeek is not between 0 and 6.
+ *
+ * @example
+ * const date = new Date('2023-09-19'); // Tuesday
+ * console.log(getEndOfWeek(date, 4)); // Next Wednesday
+ *
  */
 export function getEndOfWeek(date: Date, startOfWeek: number = 0): Date {
   if (isNaN(date.getTime())) {
@@ -31,6 +36,3 @@ export function getEndOfWeek(date: Date, startOfWeek: number = 0): Date {
   return endOfWeekDate;
 }
 
-// Example usage:
-// const date = new Date('2023-09-19'); // Tuesday
-// console.log(getEndOfWeek(date, 4)); // Next Wednesday

--- a/dateFunctions/getEndOfYear.ts
+++ b/dateFunctions/getEndOfYear.ts
@@ -4,6 +4,11 @@
  * @param date - The Date object to get the year's end from.
  * @returns A new Date object representing the end of the year.
  * @throws Will throw an error if the date is invalid.
+ *
+ * @example
+ * const date = new Date('2024-09-19');
+ * getEndOfYear(date); // '2024-12-31'
+ *
  */
 export function getEndOfYear(date: Date): Date {
   if (isNaN(date.getTime())) {
@@ -12,6 +17,3 @@ export function getEndOfYear(date: Date): Date {
   return new Date(date.getFullYear(), 11, 31);
 }
 
-// Example usage:
-// const date = new Date('2024-09-19');
-// getEndOfYear(date); // '2024-12-31'

--- a/dateFunctions/getISOWeekDate.ts
+++ b/dateFunctions/getISOWeekDate.ts
@@ -4,6 +4,11 @@
  * @param date - The Date object to get the ISO week date for.
  * @returns The ISO week date as a string.
  * @throws Will throw an error if the date is invalid.
+ *
+ * @example
+ * const date = new Date('2024-09-19');
+ * console.log(getISOWeekDate(date)); // e.g., '2024-W38-4'
+ *
  */
 export function getISOWeekDate(date: Date): string {
   if (isNaN(date.getTime())) {
@@ -38,6 +43,3 @@ export function getISOWeekDate(date: Date): string {
   return `${year}-W${String(weekNumber).padStart(2, '0')}-${dayOfWeek}`;
 }
 
-// Example usage:
-// const date = new Date('2024-09-19');
-// console.log(getISOWeekDate(date)); // e.g., '2024-W38-4'

--- a/dateFunctions/getLastDayOfPreviousMonth.ts
+++ b/dateFunctions/getLastDayOfPreviousMonth.ts
@@ -4,6 +4,11 @@
  * @param date - The Date object to get the last day of the previous month from.
  * @returns A new Date object representing the last day of the previous month.
  * @throws Will throw an error if the date is invalid.
+ *
+ * @example
+ * const today = new Date();
+ * getLastDayOfPreviousMonth(today); // Last day of the month before today
+ *
  */
 export function getLastDayOfPreviousMonth(date: Date): Date {
   if (isNaN(date.getTime())) {
@@ -15,6 +20,3 @@ export function getLastDayOfPreviousMonth(date: Date): Date {
   return new Date(year, month, 0);
 }
 
-// Example usage:
-// const today = new Date();
-// getLastDayOfPreviousMonth(today); // Last day of the month before today

--- a/dateFunctions/getNextMonth.ts
+++ b/dateFunctions/getNextMonth.ts
@@ -4,6 +4,11 @@
  * @param date - The Date object to get the next month's date from.
  * @returns A new Date object representing the same day in the next month.
  * @throws Will throw an error if the date is invalid.
+ *
+ * @example
+ * const today = new Date();
+ * getNextMonth(today); // Date for the same day next month
+ *
  */
 export function getNextMonth(date: Date): Date {
   if (isNaN(date.getTime())) {
@@ -15,6 +20,3 @@ export function getNextMonth(date: Date): Date {
   return result;
 }
 
-// Example usage:
-// const today = new Date();
-// getNextMonth(today); // Date for the same day next month

--- a/dateFunctions/getNextOccurrence.ts
+++ b/dateFunctions/getNextOccurrence.ts
@@ -5,6 +5,11 @@
  * @param dayOfWeek - The day of the week to find the next occurrence of (0 for Sunday, 1 for Monday, etc.).
  * @returns A new Date object representing the next occurrence of the specified day of the week.
  * @throws Will throw an error if the date is invalid or if the dayOfWeek is not between 0 and 6.
+ *
+ * @example
+ * const date = new Date('2023-09-19'); // Tuesday
+ * console.log(getNextOccurrence(date, 4)); // Next Thursday
+ *
  */
 export function getNextOccurrence(date: Date, dayOfWeek: number): Date {
   if (isNaN(date.getTime())) {
@@ -25,6 +30,3 @@ export function getNextOccurrence(date: Date, dayOfWeek: number): Date {
   return resultDate;
 }
 
-// Example usage:
-// const date = new Date('2023-09-19'); // Tuesday
-// console.log(getNextOccurrence(date, 4)); // Next Thursday

--- a/dateFunctions/getPreviousMonth.ts
+++ b/dateFunctions/getPreviousMonth.ts
@@ -4,6 +4,11 @@
  * @param date - The Date object to start from.
  * @returns A new Date object representing the same day of the previous month.
  * @throws Will throw an error if the date is invalid.
+ *
+ * @example
+ * const date = new Date('2023-12-31');
+ * console.log(getPreviousMonth(date)); // 2023-11-30
+ *
  */
 export function getPreviousMonth(date: Date): Date {
   if (isNaN(date.getTime())) {
@@ -21,6 +26,3 @@ export function getPreviousMonth(date: Date): Date {
   return resultDate;
 }
 
-// Example usage:
-// const date = new Date('2023-12-31');
-// console.log(getPreviousMonth(date)); // 2023-11-30

--- a/dateFunctions/getQuarter.ts
+++ b/dateFunctions/getQuarter.ts
@@ -4,6 +4,11 @@
  * @param date - The Date object to get the quarter for.
  * @returns The quarter of the year (1-4).
  * @throws Will throw an error if the date is invalid.
+ *
+ * @example
+ * const date = new Date('2024-09-19');
+ * getQuarter(date); // 3 (Q3)
+ *
  */
 export function getQuarter(date: Date): number {
   if (isNaN(date.getTime())) {
@@ -14,6 +19,3 @@ export function getQuarter(date: Date): number {
   return Math.ceil(month / 3);
 }
 
-// Example usage:
-// const date = new Date('2024-09-19');
-// getQuarter(date); // 3 (Q3)

--- a/dateFunctions/getStartOfWeek.ts
+++ b/dateFunctions/getStartOfWeek.ts
@@ -5,6 +5,11 @@
  * @param startOfWeek - The start day of the week (0 for Sunday, 1 for Monday, etc.).
  * @returns A new Date object representing the start of the week.
  * @throws Will throw an error if the date is invalid or if the startOfWeek is not between 0 and 6.
+ *
+ * @example
+ * const date = new Date('2024-09-19');
+ * getStartOfWeek(date); // Gets the Sunday of the week containing '2024-09-19'
+ *
  */
 export function getStartOfWeek(date: Date, startOfWeek: number = 0): Date {
   if (isNaN(date.getTime())) {
@@ -24,6 +29,3 @@ export function getStartOfWeek(date: Date, startOfWeek: number = 0): Date {
   return startOfWeekDate;
 }
 
-// Example usage:
-// const date = new Date('2024-09-19');
-// getStartOfWeek(date); // Gets the Sunday of the week containing '2024-09-19'

--- a/dateFunctions/getStartOfYear.ts
+++ b/dateFunctions/getStartOfYear.ts
@@ -3,6 +3,11 @@
  *
  * @param date - The Date object to get the year's start from.
  * @returns A new Date object representing the start of the year.
+ *
+ * @example
+ * const date = new Date('2024-09-19');
+ * getStartOfYear(date); // '2024-01-01'
+ *
  */
 export function getStartOfYear(date: Date): Date {
   if (isNaN(date.getTime())) {
@@ -11,6 +16,3 @@ export function getStartOfYear(date: Date): Date {
   return new Date(date.getFullYear(), 0, 1);
 }
 
-// Example usage:
-// const date = new Date('2024-09-19');
-// getStartOfYear(date); // '2024-01-01'

--- a/dateFunctions/getWeekNumber.ts
+++ b/dateFunctions/getWeekNumber.ts
@@ -4,6 +4,11 @@
  * @param date - The Date object to get the week number for.
  * @returns The week number of the year.
  * @throws Will throw an error if the date is invalid.
+ *
+ * @example
+ * const date = new Date('2024-09-19');
+ * getWeekNumber(date); // e.g., 38
+ *
  */
 export function getWeekNumber(date: Date): number {
   if (isNaN(date.getTime())) {
@@ -17,6 +22,3 @@ export function getWeekNumber(date: Date): number {
   return Math.ceil((days + start.getDay() + 1) / 7);
 }
 
-// Example usage:
-// const date = new Date('2024-09-19');
-// getWeekNumber(date); // e.g., 38

--- a/dateFunctions/getWeekRange.ts
+++ b/dateFunctions/getWeekRange.ts
@@ -8,6 +8,11 @@ import { getEndOfWeek } from './getEndOfWeek';
  * @param startOfWeek - The start day of the week (0 for Sunday, 1 for Monday, etc.).
  * @returns An object with the start and end dates of the week.
  * @throws Will throw an error if the date is invalid or if startOfWeek is not a valid number.
+ *
+ * @example
+ * const date = new Date('2024-09-19');
+ * getWeekRange(date); // { start: '2024-09-15', end: '2024-09-21' }
+ *
  */
 export function getWeekRange(
   date: Date,
@@ -27,6 +32,3 @@ export function getWeekRange(
   return { start, end };
 }
 
-// Example usage:
-// const date = new Date('2024-09-19');
-// getWeekRange(date); // { start: '2024-09-15', end: '2024-09-21' }

--- a/dateFunctions/getWeekdaysInMonth.ts
+++ b/dateFunctions/getWeekdaysInMonth.ts
@@ -3,6 +3,11 @@
  *
  * @param date - The Date object representing the month to calculate weekdays for.
  * @returns The number of weekdays in the month.
+ *
+ * @example
+ * const date = new Date('2024-09-01');
+ * getWeekdaysInMonth(date); // Number of weekdays in September 2024
+ *
  */
 export function getWeekdaysInMonth(date: Date): number {
   if (isNaN(date.getTime())) {
@@ -25,6 +30,3 @@ export function getWeekdaysInMonth(date: Date): number {
   return weekdayCount;
 }
 
-// Example usage:
-// const date = new Date('2024-09-01');
-// getWeekdaysInMonth(date); // Number of weekdays in September 2024

--- a/dateFunctions/isLeapYear.ts
+++ b/dateFunctions/isLeapYear.ts
@@ -4,6 +4,11 @@
  * @param year - The year to check.
  * @returns True if the year is a leap year, false otherwise.
  * @throws Will throw an error if the year is NaN.
+ *
+ * @example
+ * isLeapYear(2024); // true
+ * isLeapYear(2023); // false
+ *
  */
 export function isLeapYear(year: number): boolean {
   if (isNaN(year)) {
@@ -12,6 +17,3 @@ export function isLeapYear(year: number): boolean {
   return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
 }
 
-// Example usage:
-// isLeapYear(2024); // true
-// isLeapYear(2023); // false

--- a/dateFunctions/isToday.ts
+++ b/dateFunctions/isToday.ts
@@ -4,6 +4,11 @@
  * @param date - The Date object to check.
  * @returns True if the date is today, false otherwise.
  * @throws Will throw an error if the date is invalid.
+ *
+ * @example
+ * const date = new Date();
+ * isToday(date); // true if today
+ *
  */
 export function isToday(date: Date): boolean {
   if (isNaN(date.getTime())) {
@@ -17,6 +22,3 @@ export function isToday(date: Date): boolean {
   );
 }
 
-// Example usage:
-// const date = new Date();
-// isToday(date); // true if today

--- a/dateFunctions/isWeekend.ts
+++ b/dateFunctions/isWeekend.ts
@@ -4,6 +4,11 @@
  * @param date - The Date object to check.
  * @returns True if the date is a Saturday or Sunday, false otherwise.
  * @throws Will throw an error if the date is invalid.
+ *
+ * @example
+ * const date = new Date('2024-09-21'); // Saturday
+ * isWeekend(date); // true
+ *
  */
 export function isWeekend(date: Date): boolean {
   if (isNaN(date.getTime())) {
@@ -13,6 +18,3 @@ export function isWeekend(date: Date): boolean {
   return day === 0 || day === 6;
 }
 
-// Example usage:
-// const date = new Date('2024-09-21'); // Saturday
-// isWeekend(date); // true

--- a/dateFunctions/oneWeekAgo.ts
+++ b/dateFunctions/oneWeekAgo.ts
@@ -4,6 +4,11 @@
  * @param date - The Date object to subtract one week from.
  * @returns A new Date object representing the date one week ago.
  * @throws Will throw an error if the date is invalid.
+ *
+ * @example
+ * const today = new Date();
+ * oneWeekAgo(today); // Date one week before today
+ *
  */
 export function oneWeekAgo(date: Date): Date {
   if (isNaN(date.getTime())) {
@@ -14,6 +19,3 @@ export function oneWeekAgo(date: Date): Date {
   return result;
 }
 
-// Example usage:
-// const today = new Date();
-// oneWeekAgo(today); // Date one week before today

--- a/dateFunctions/toUTCDate.ts
+++ b/dateFunctions/toUTCDate.ts
@@ -4,6 +4,11 @@
  * @param date - The local Date object to convert.
  * @returns A new Date object representing the same moment in UTC.
  * @throws Will throw an error if the date is invalid.
+ *
+ * @example
+ * const localDate = new Date('2024-09-19T15:45:30');
+ * toUTCDate(localDate); // e.g., '2024-09-19T15:45:30.000Z'
+ *
  */
 export function toUTCDate(date: Date): Date {
   if (isNaN(date.getTime())) {
@@ -22,6 +27,3 @@ export function toUTCDate(date: Date): Date {
   );
 }
 
-// Example usage:
-// const localDate = new Date('2024-09-19T15:45:30');
-// toUTCDate(localDate); // e.g., '2024-09-19T15:45:30.000Z'

--- a/encodingFunctions/decodeBase64.ts
+++ b/encodingFunctions/decodeBase64.ts
@@ -5,10 +5,12 @@ import { Buffer } from 'buffer';
  *
  * @param str - The base64 encoded string to decode.
  * @returns The decoded string.
+ *
+ * @example
+ * decodeBase64("aGVsbG8gd29ybGQ="); // "hello world"
+ *
  */
 export function decodeBase64(str: string): string {
   return Buffer.from(str, 'base64').toString('utf-8');
 }
 
-// Example usage:
-// decodeBase64("aGVsbG8gd29ybGQ="); // "hello world"

--- a/encodingFunctions/encodeBase64.ts
+++ b/encodingFunctions/encodeBase64.ts
@@ -5,6 +5,10 @@ import { Buffer } from 'buffer';
  *
  * @param str - The string to encode.
  * @returns The base64 encoded string.
+ *
+ * @example
+ * encodeBase64("hello world"); // "aGVsbG8gd29ybGQ"
+ *
  */
 export function encodeBase64(str: string): string {
   return Buffer.from(str)
@@ -14,5 +18,3 @@ export function encodeBase64(str: string): string {
     .replace(/=+$/, '');
 }
 
-// Example usage:
-// encodeBase64("hello world"); // "aGVsbG8gd29ybGQ"

--- a/mathFunctions/absoluteValue.ts
+++ b/mathFunctions/absoluteValue.ts
@@ -3,6 +3,10 @@
  *
  * @param n - The number to find the absolute value of.
  * @returns The absolute value of the number.
+ *
+ * @example
+ * absoluteValue(-5); // 5
+ *
  */
 export function absoluteValue(n: number): number {
   if (isNaN(n)) {
@@ -12,5 +16,3 @@ export function absoluteValue(n: number): number {
   return Math.abs(n);
 }
 
-// Example usage:
-// absoluteValue(-5); // 5

--- a/mathFunctions/calculateBinomialCoefficient.ts
+++ b/mathFunctions/calculateBinomialCoefficient.ts
@@ -7,6 +7,10 @@ import { calculateFactorial } from './calculateFactorial';
  * @param k - The number of items to choose.
  * @returns The binomial coefficient.
  * @throws Will throw an error if n or k is not an integer, if n or k is NaN, or if n or k is negative.
+ *
+ * @example
+ * calculateBinomialCoefficient(5, 2); // 10
+ *
  */
 export function calculateBinomialCoefficient(n: number, k: number): number {
   if (isNaN(n) || isNaN(k)) {
@@ -26,5 +30,3 @@ export function calculateBinomialCoefficient(n: number, k: number): number {
   );
 }
 
-// Example usage:
-// calculateBinomialCoefficient(5, 2); // 10

--- a/mathFunctions/calculateCombination.ts
+++ b/mathFunctions/calculateCombination.ts
@@ -7,6 +7,10 @@ import { calculateFactorial } from './calculateFactorial';
  * @param k - The number of items to choose.
  * @returns The number of ways to choose k items from n items.
  * @throws Will throw an error if n or k is not an integer, if n or k is NaN, or if n or k is negative.
+ *
+ * @example
+ * calculateCombination(5, 2); // 10
+ *
  */
 export function calculateCombination(n: number, k: number): number {
   if (isNaN(n) || isNaN(k)) {
@@ -26,5 +30,3 @@ export function calculateCombination(n: number, k: number): number {
   );
 }
 
-// Example usage:
-// calculateCombination(5, 2); // 10

--- a/mathFunctions/calculateCubeRoot.ts
+++ b/mathFunctions/calculateCubeRoot.ts
@@ -4,6 +4,10 @@
  * @param n - The number to find the cube root of.
  * @returns The cube root of the number.
  * @throws Will throw an error if n is NaN.
+ *
+ * @example
+ * calculateCubeRoot(27); // 3
+ *
  */
 export function calculateCubeRoot(n: number): number {
   if (isNaN(n)) {
@@ -12,5 +16,3 @@ export function calculateCubeRoot(n: number): number {
   return Math.cbrt(n);
 }
 
-// Example usage:
-// calculateCubeRoot(27); // 3

--- a/mathFunctions/calculateExponential.ts
+++ b/mathFunctions/calculateExponential.ts
@@ -3,10 +3,12 @@
  *
  * @param n - The exponent.
  * @returns The result of e raised to the power of n.
+ *
+ * @example
+ * exponential(1); // 2.718...
+ *
  */
 export function calculateExponential(n: number): number {
   return Math.exp(n);
 }
 
-// Example usage:
-// exponential(1); // 2.718...

--- a/mathFunctions/calculateFactorial.ts
+++ b/mathFunctions/calculateFactorial.ts
@@ -4,6 +4,10 @@
  * @param n - The number to calculate the factorial of.
  * @returns The factorial of the number.
  * @throws Will throw an error if n is not an integer, if n is NaN, or if n is negative.
+ *
+ * @example
+ * calculateFactorial(5); // 120
+ *
  */
 export function calculateFactorial(n: number): number {
   if (isNaN(n)) {
@@ -21,5 +25,3 @@ export function calculateFactorial(n: number): number {
   return n * calculateFactorial(n - 1);
 }
 
-// Example usage:
-// calculateFactorial(5); // 120

--- a/mathFunctions/calculateLogBase10.ts
+++ b/mathFunctions/calculateLogBase10.ts
@@ -3,10 +3,12 @@
  *
  * @param n - The number to calculate the logarithm of.
  * @returns The base 10 logarithm of the number.
+ *
+ * @example
+ * logBase10(100); // 2
+ *
  */
 export function calculatLogBase10(n: number): number {
   return Math.log10(n);
 }
 
-// Example usage:
-// logBase10(100); // 2

--- a/mathFunctions/calculateLogarithm.ts
+++ b/mathFunctions/calculateLogarithm.ts
@@ -5,6 +5,10 @@
  * @param base - The base of the logarithm (default is e for natural logarithm).
  * @returns The logarithm of the number with the specified base.
  * @throws Will throw an error if n or base is NaN, if n is negative, if base is less than or equal to 0, or if base is 1.
+ *
+ * @example
+ * calculateLogarithm(100, 10); // 2
+ *
  */
 export function calculateLogarithm(n: number, base: number = Math.E): number {
   if (isNaN(n) || isNaN(base)) {
@@ -19,5 +23,3 @@ export function calculateLogarithm(n: number, base: number = Math.E): number {
   return Math.log(n) / Math.log(base);
 }
 
-// Example usage:
-// calculateLogarithm(100, 10); // 2

--- a/mathFunctions/calculateNaturalLogarithm.ts
+++ b/mathFunctions/calculateNaturalLogarithm.ts
@@ -3,10 +3,12 @@
  *
  * @param n - The number to find the natural logarithm of.
  * @returns The natural logarithm of the number.
+ *
+ * @example
+ * naturalLogarithm(Math.E); // 1
+ *
  */
 export function calculateNaturalLogarithm(n: number): number {
   return Math.log(n);
 }
 
-// Example usage:
-// naturalLogarithm(Math.E); // 1

--- a/mathFunctions/calculatePercentage.ts
+++ b/mathFunctions/calculatePercentage.ts
@@ -4,10 +4,12 @@
  * @param total - The total value.
  * @param part - The part value to calculate the percentage of.
  * @returns The percentage of the part with respect to the total.
+ *
+ * @example
+ * calculatePercentage(200, 50); // 25
+ *
  */
 export function calculatePercentage(total: number, part: number): number {
   return (part / total) * 100;
 }
 
-// Example usage:
-// calculatePercentage(200, 50); // 25

--- a/mathFunctions/calculatePermutation.ts
+++ b/mathFunctions/calculatePermutation.ts
@@ -7,6 +7,10 @@ import { calculateFactorial } from './calculateFactorial';
  * @param k - The number of items to arrange.
  * @returns The number of ways to arrange k items from n items.
  * @throws Will throw an error if n or k is not an integer, if n or k is NaN, or if n or k is negative.
+ *
+ * @example
+ * calculatePermutation(5, 2); // 20
+ *
  */
 export function calculatePermutation(n: number, k: number): number {
   if (isNaN(n) || isNaN(k)) {
@@ -24,5 +28,3 @@ export function calculatePermutation(n: number, k: number): number {
   return calculateFactorial(n) / calculateFactorial(n - k);
 }
 
-// Example usage:
-// calculatePermutation(5, 2); // 20

--- a/mathFunctions/calculatePower.ts
+++ b/mathFunctions/calculatePower.ts
@@ -4,10 +4,12 @@
  * @param base - The base number.
  * @param exponent - The exponent.
  * @returns The base raised to the power of the exponent.
+ *
+ * @example
+ * power(2, 3); // 8
+ *
  */
 export function calculatePower(base: number, exponent: number): number {
   return Math.pow(base, exponent);
 }
 
-// Example usage:
-// power(2, 3); // 8

--- a/mathFunctions/calculateSquareRoot.ts
+++ b/mathFunctions/calculateSquareRoot.ts
@@ -4,6 +4,10 @@
  * @param n - The number to find the square root of.
  * @returns The square root of the number.
  * @throws Will throw an error if n is negative or if n is NaN.
+ *
+ * @example
+ * calculateSquareRoot(9); // 3
+ *
  */
 export function calculateSquareRoot(n: number): number {
   if (isNaN(n)) {
@@ -15,5 +19,3 @@ export function calculateSquareRoot(n: number): number {
   return Math.sqrt(n);
 }
 
-// Example usage:
-// calculateSquareRoot(9); // 3

--- a/mathFunctions/calculateTriangularNumber.ts
+++ b/mathFunctions/calculateTriangularNumber.ts
@@ -4,6 +4,10 @@
  * @param n - The position in the triangular number sequence.
  * @returns The nth triangular number.
  * @throws Will throw an error if n is not an integer or if n is negative.
+ *
+ * @example
+ * calculateTriangularNumber(5); // 15
+ *
  */
 export function calculateTriangularNumber(n: number): number {
   if (isNaN(n)) {
@@ -18,5 +22,3 @@ export function calculateTriangularNumber(n: number): number {
   return (n * (n + 1)) / 2;
 }
 
-// Example usage:
-// calculateTriangularNumber(5); // 15

--- a/mathFunctions/ceilValue.ts
+++ b/mathFunctions/ceilValue.ts
@@ -4,6 +4,10 @@
  * @param n - The number to round up.
  * @returns The number rounded up to the nearest integer.
  * @throws Will throw an error if n is NaN.
+ *
+ * @example
+ * ceilValue(4.2); // 5
+ *
  */
 export function ceilValue(n: number): number {
   if (isNaN(n)) {
@@ -13,5 +17,3 @@ export function ceilValue(n: number): number {
   return result === -0 ? 0 : result;
 }
 
-// Example usage:
-// ceilValue(4.2); // 5

--- a/mathFunctions/fibonacciIterative.ts
+++ b/mathFunctions/fibonacciIterative.ts
@@ -4,6 +4,10 @@
  * @param n - The position in the Fibonacci sequence.
  * @returns The nth Fibonacci number.
  * @throws Will throw an error if n is not an integer or if n is NaN.
+ *
+ * @example
+ * fibonacciIterative(6); // 8
+ *
  */
 export function fibonacciIterative(n: number): number {
   if (isNaN(n)) {
@@ -26,5 +30,3 @@ export function fibonacciIterative(n: number): number {
   return n === 0 ? 0 : b;
 }
 
-// Example usage:
-// fibonacciIterative(6); // 8

--- a/mathFunctions/fibonacciRecursive.ts
+++ b/mathFunctions/fibonacciRecursive.ts
@@ -4,6 +4,10 @@
  * @param n - The position in the Fibonacci sequence.
  * @returns The nth Fibonacci number.
  * @throws Will throw an error if n is not an integer, if n is NaN, or if n is negative.
+ *
+ * @example
+ * fibonacciRecursive(6); // 8
+ *
  */
 export function fibonacciRecursive(n: number): number {
   if (isNaN(n)) {
@@ -21,5 +25,3 @@ export function fibonacciRecursive(n: number): number {
   return fibonacciRecursive(n - 1) + fibonacciRecursive(n - 2);
 }
 
-// Example usage:
-// fibonacciRecursive(6); // 8

--- a/mathFunctions/floorValue.ts
+++ b/mathFunctions/floorValue.ts
@@ -3,10 +3,12 @@
  *
  * @param n - The number to round down.
  * @returns The number rounded down to the nearest integer.
+ *
+ * @example
+ * floorValue(4.7); // 4
+ *
  */
 export function floorValue(n: number): number {
   return Math.floor(n);
 }
 
-// Example usage:
-// floorValue(4.7); // 4

--- a/mathFunctions/gcd.ts
+++ b/mathFunctions/gcd.ts
@@ -5,6 +5,10 @@
  * @param b - The second number.
  * @returns The greatest common divisor of a and b.
  * @throws Will throw an error if a or b is NaN or if a or b is not an integer.
+ *
+ * @example
+ * gcd(12, 15); // 3
+ *
  */
 export function gcd(a: number, b: number): number {
   if (isNaN(a) || isNaN(b)) {
@@ -18,5 +22,3 @@ export function gcd(a: number, b: number): number {
   return b === 0 ? a : gcd(b, a % b);
 }
 
-// Example usage:
-// gcd(12, 15); // 3

--- a/mathFunctions/getRandomIntInRange.ts
+++ b/mathFunctions/getRandomIntInRange.ts
@@ -5,6 +5,10 @@
  * @param max - The maximum value (inclusive).
  * @returns A random integer between min and max.
  * @throws Will throw an error if min is greater than max, if min or max is NaN, or if min or max is not an integer.
+ *
+ * @example
+ * getRandomIntInRange(1, 10); // Random integer between 1 and 10
+ *
  */
 export function getRandomIntInRange(min: number, max: number): number {
   if (isNaN(min) || isNaN(max)) {
@@ -21,5 +25,3 @@ export function getRandomIntInRange(min: number, max: number): number {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-// Example usage:
-// getRandomIntInRange(1, 10); // Random integer between 1 and 10

--- a/mathFunctions/isEven.ts
+++ b/mathFunctions/isEven.ts
@@ -3,11 +3,13 @@
  *
  * @param n - The number to check.
  * @returns True if the number is even, false if it is odd.
+ *
+ * @example
+ * isEven(4); // true
+ * isEven(3); // false
+ *
  */
 export function isEven(n: number): boolean {
   return n % 2 === 0;
 }
 
-// Example usage:
-// isEven(4); // true
-// isEven(3); // false

--- a/mathFunctions/isOdd.ts
+++ b/mathFunctions/isOdd.ts
@@ -4,6 +4,11 @@
  * @param n - The number to check.
  * @returns True if the number is odd, false if it is even.
  * @throws Will throw an error if n is NaN or if n is not an integer.
+ *
+ * @example
+ * isOdd(3); // true
+ * isOdd(4); // false
+ *
  */
 export function isOdd(n: number): boolean {
   if (isNaN(n)) {
@@ -15,6 +20,3 @@ export function isOdd(n: number): boolean {
   return n % 2 !== 0;
 }
 
-// Example usage:
-// isOdd(3); // true
-// isOdd(4); // false

--- a/mathFunctions/isPerfectSquare.ts
+++ b/mathFunctions/isPerfectSquare.ts
@@ -3,11 +3,13 @@
  *
  * @param n - The number to check.
  * @returns True if the number is a perfect square, false otherwise.
+ *
+ * @example
+ * isPerfectSquare(16); // true
+ * isPerfectSquare(15); // false
+ *
  */
 export function isPerfectSquare(n: number): boolean {
   return Number.isInteger(Math.sqrt(n));
 }
 
-// Example usage:
-// isPerfectSquare(16); // true
-// isPerfectSquare(15); // false

--- a/mathFunctions/isPrime.ts
+++ b/mathFunctions/isPrime.ts
@@ -4,6 +4,11 @@
  * @param n - The number to check.
  * @returns True if the number is prime, false otherwise.
  * @throws Will throw an error if n is NaN.
+ *
+ * @example
+ * isPrime(7); // true
+ * isPrime(10); // false
+ *
  */
 export function isPrime(n: number): boolean {
   if (isNaN(n)) {
@@ -20,6 +25,3 @@ export function isPrime(n: number): boolean {
   return true;
 }
 
-// Example usage:
-// isPrime(7); // true
-// isPrime(10); // false

--- a/mathFunctions/lcm.ts
+++ b/mathFunctions/lcm.ts
@@ -7,6 +7,10 @@ import { gcd } from './gcd';
  * @param b - The second number.
  * @returns The least common multiple of a and b.
  * @throws Will throw an error if both a and b are zero, if a or b is NaN, or if a or b is not an integer.
+ *
+ * @example
+ * lcm(12, 15); // 60
+ *
  */
 export function lcm(a: number, b: number): number {
   if (isNaN(a) || isNaN(b)) {
@@ -21,5 +25,3 @@ export function lcm(a: number, b: number): number {
   return Math.abs((a * b) / gcd(a, b));
 }
 
-// Example usage:
-// lcm(12, 15); // 60

--- a/mathFunctions/oddOrEven.ts
+++ b/mathFunctions/oddOrEven.ts
@@ -4,6 +4,11 @@
  * @param n - The number to check.
  * @returns "odd" if the number is odd, "even" if the number is even.
  * @throws Will throw an error if n is not an integer or if n is NaN.
+ *
+ * @example
+ * console.log(oddOrEven(3)); // "odd"
+ * console.log(oddOrEven(4)); // "even"
+ *
  */
 export function oddOrEven(n: number): string {
   if (isNaN(n)) {
@@ -15,6 +20,3 @@ export function oddOrEven(n: number): string {
   return n % 2 === 0 ? 'even' : 'odd';
 }
 
-// Example usage:
-// console.log(oddOrEven(3)); // "odd"
-// console.log(oddOrEven(4)); // "even"

--- a/mathFunctions/roundToDecimals.ts
+++ b/mathFunctions/roundToDecimals.ts
@@ -5,6 +5,10 @@
  * @param decimals - The number of decimal places.
  * @returns The rounded number.
  * @throws Will throw an error if value or decimals is NaN, if decimals is not an integer, or if decimals is negative.
+ *
+ * @example
+ * roundToDecimals(5.6789, 2); // 5.68
+ *
  */
 export function roundToDecimals(value: number, decimals: number): number {
   if (isNaN(value) || isNaN(decimals)) {
@@ -20,5 +24,3 @@ export function roundToDecimals(value: number, decimals: number): number {
   return Math.round(value * factor) / factor;
 }
 
-// Example usage:
-// roundToDecimals(5.6789, 2); // 5.68

--- a/mathFunctions/roundValue.ts
+++ b/mathFunctions/roundValue.ts
@@ -4,6 +4,10 @@
  * @param n - The number to round.
  * @returns The number rounded to the nearest integer.
  * @throws Will throw an error if n is NaN.
+ *
+ * @example
+ * roundValue(4.5); // 5
+ *
  */
 export function roundValue(n: number): number {
   if (isNaN(n)) {
@@ -13,5 +17,3 @@ export function roundValue(n: number): number {
   return result === -0 ? 0 : result;
 }
 
-// Example usage:
-// roundValue(4.5); // 5

--- a/stringFunctions/areAnagrams.ts
+++ b/stringFunctions/areAnagrams.ts
@@ -4,6 +4,10 @@
  * @param str1 - The first string.
  * @param str2 - The second string.
  * @returns True if the strings are anagrams, false otherwise.
+ *
+ * @example
+ * areAnagrams("listen", "silent"); // true
+ *
  */
 export function areAnagrams(str1: string, str2: string): boolean {
   const normalize = (str: string) =>
@@ -11,5 +15,3 @@ export function areAnagrams(str1: string, str2: string): boolean {
   return normalize(str1) === normalize(str2);
 }
 
-// Example usage:
-// areAnagrams("listen", "silent"); // true

--- a/stringFunctions/capitalizeEachWord.ts
+++ b/stringFunctions/capitalizeEachWord.ts
@@ -3,10 +3,12 @@
  *
  * @param str - The string to capitalize.
  * @returns A new string with the first letter of each word capitalized.
+ *
+ * @example
+ * capitalizeEachWord("hello world"); // "Hello World"
+ *
  */
 export function capitalizeEachWord(str: string): string {
   return str.replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
-// Example usage:
-// capitalizeEachWord("hello world"); // "Hello World"

--- a/stringFunctions/capitalizeFirstLetter.ts
+++ b/stringFunctions/capitalizeFirstLetter.ts
@@ -3,6 +3,10 @@
  *
  * @param str - The string to capitalize.
  * @returns The capitalized string.
+ *
+ * @example
+ * capitalizeFirstLetter("hello"); // "Hello"
+ *
  */
 export function capitalizeFirstLetter(str: string): string {
   if (str.length === 0) {
@@ -11,5 +15,3 @@ export function capitalizeFirstLetter(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
-// Example usage:
-// capitalizeFirstLetter("hello"); // "Hello"

--- a/stringFunctions/capitalizeNthLetter.ts
+++ b/stringFunctions/capitalizeNthLetter.ts
@@ -4,11 +4,13 @@
  * @param str - The string to process.
  * @param n - The position of the letter to capitalize (0-based index).
  * @returns A new string with the nth letter capitalized.
+ *
+ * @example
+ * capitalizeNthLetter("hello world", 6); // "hello World"
+ *
  */
 export function capitalizeNthLetter(str: string, n: number): string {
   if (n < 0 || n >= str.length) return str;
   return str.slice(0, n) + str.charAt(n).toUpperCase() + str.slice(n + 1);
 }
 
-// Example usage:
-// capitalizeNthLetter("hello world", 6); // "hello World"

--- a/stringFunctions/countCharacterOccurrences.ts
+++ b/stringFunctions/countCharacterOccurrences.ts
@@ -4,10 +4,12 @@
  * @param str - The string to analyze.
  * @param char - The character to count.
  * @returns The count of occurrences.
+ *
+ * @example
+ * countCharacterOccurrences("hello world", "l"); // 3
+ *
  */
 export function countCharacterOccurrences(str: string, char: string): number {
   return (str.match(new RegExp(char, 'g')) || []).length;
 }
 
-// Example usage:
-// countCharacterOccurrences("hello world", "l"); // 3

--- a/stringFunctions/countConsonants.ts
+++ b/stringFunctions/countConsonants.ts
@@ -3,10 +3,12 @@
  *
  * @param str - The string to analyze.
  * @returns The number of consonants in the string.
+ *
+ * @example
+ * countConsonants("Hello world"); // 7
+ *
  */
 export function countConsonants(str: string): number {
   return (str.match(/[bcdfghjklmnpqrstvwxyz]/gi) || []).length;
 }
 
-// Example usage:
-// countConsonants("Hello world"); // 7

--- a/stringFunctions/countSubstring.ts
+++ b/stringFunctions/countSubstring.ts
@@ -4,11 +4,13 @@
  * @param str - The string to analyze.
  * @param substring - The substring to count.
  * @returns The count of occurrences.
+ *
+ * @example
+ * countSubstring("hello world, hello universe", "hello"); // 2
+ *
  */
 export function countSubstring(str: string, substring: string): number {
   if (substring.length === 0) return 0;
   return (str.match(new RegExp(substring, 'g')) || []).length;
 }
 
-// Example usage:
-// countSubstring("hello world, hello universe", "hello"); // 2

--- a/stringFunctions/countVowels.ts
+++ b/stringFunctions/countVowels.ts
@@ -3,10 +3,12 @@
  *
  * @param str - The string to analyze.
  * @returns The number of vowels in the string.
+ *
+ * @example
+ * countVowels("Hello world"); // 3
+ *
  */
 export function countVowels(str: string): number {
   return (str.match(/[aeiou]/gi) || []).length;
 }
 
-// Example usage:
-// countVowels("Hello world"); // 3

--- a/stringFunctions/countWords.ts
+++ b/stringFunctions/countWords.ts
@@ -3,6 +3,10 @@
  *
  * @param str - The string to analyze.
  * @returns The number of words in the string.
+ *
+ * @example
+ * countWords("Hello world! This is a test."); // 6
+ *
  */
 export function countWords(str: string): number {
   if (str.trim() === '') {
@@ -11,5 +15,3 @@ export function countWords(str: string): number {
   return str.trim().split(/\s+/).length;
 }
 
-// Example usage:
-// countWords("Hello world! This is a test."); // 6

--- a/stringFunctions/endsWith.ts
+++ b/stringFunctions/endsWith.ts
@@ -4,10 +4,12 @@
  * @param str - The string to check.
  * @param end - The substring to check for.
  * @returns True if the string ends with the substring, false otherwise.
+ *
+ * @example
+ * endsWith("hello world", "world"); // true
+ *
  */
 export function endsWith(str: string, end: string): boolean {
   return str.endsWith(end);
 }
 
-// Example usage:
-// endsWith("hello world", "world"); // true

--- a/stringFunctions/extractSubstring.ts
+++ b/stringFunctions/extractSubstring.ts
@@ -6,6 +6,10 @@
  * @param length - The length of the substring.
  * @returns The extracted substring.
  * @throws An error if the start index or length is invalid.
+ *
+ * @example
+ * extractSubstring("hello world", 6, 5); // "world"
+ *
  */
 export function extractSubstring(
   str: string,
@@ -26,5 +30,3 @@ export function extractSubstring(
   return str.slice(start, start + length);
 }
 
-// Example usage:
-// extractSubstring("hello world", 6, 5); // "world"

--- a/stringFunctions/findLongestWord.ts
+++ b/stringFunctions/findLongestWord.ts
@@ -3,6 +3,10 @@
  *
  * @param str - The string to analyze.
  * @returns The longest word in the string.
+ *
+ * @example
+ * console.log(findLongestWord("The quick brown fox jumps over the lazy dog.")); // "jumps"
+ *
  */
 export function findLongestWord(str: string): string {
   // Remove punctuation and special characters
@@ -17,5 +21,3 @@ export function findLongestWord(str: string): string {
   }, '');
 }
 
-// Example usage:
-// console.log(findLongestWord("The quick brown fox jumps over the lazy dog.")); // "jumps"

--- a/stringFunctions/firstNonRepeatingCharacter.ts
+++ b/stringFunctions/firstNonRepeatingCharacter.ts
@@ -3,6 +3,10 @@
  *
  * @param str - The string to analyze.
  * @returns The first non-repeating character, or null if none exist.
+ *
+ * @example
+ * firstNonRepeatingCharacter("abacabad"); // 'c'
+ *
  */
 export function firstNonRepeatingCharacter(str: string): string | null {
   // Create an object to store the count of each character
@@ -24,5 +28,3 @@ export function firstNonRepeatingCharacter(str: string): string | null {
   return null;
 }
 
-// Example usage:
-// firstNonRepeatingCharacter("abacabad"); // 'c'

--- a/stringFunctions/generateRandomAlphanumeric.ts
+++ b/stringFunctions/generateRandomAlphanumeric.ts
@@ -4,6 +4,10 @@
  * @param length - The length of the generated string.
  * @returns A random alphanumeric string of the specified length.
  * @throws An error if the length is invalid.
+ *
+ * @example
+ * generateRandomAlphanumeric(10); // e.g., "aB3dE5fG7H"
+ *
  */
 export function generateRandomAlphanumeric(length: number): string {
   if (isNaN(length) || length < 0) {
@@ -19,5 +23,3 @@ export function generateRandomAlphanumeric(length: number): string {
   return result;
 }
 
-// Example usage:
-// generateRandomAlphanumeric(10); // e.g., "aB3dE5fG7H"

--- a/stringFunctions/generateRandomString.ts
+++ b/stringFunctions/generateRandomString.ts
@@ -5,6 +5,10 @@
  * @param charset - The character set to use for generating the string.
  * @returns A random string of the specified length from the specified character set.
  * @throws An error if the length is invalid or the charset is empty.
+ *
+ * @example
+ * generateRandomString(10, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'); // e.g., "aB3dE5fG7H"
+ *
  */
 export function generateRandomString(
   length: number,
@@ -23,5 +27,3 @@ export function generateRandomString(
   return result;
 }
 
-// Example usage:
-// generateRandomString(10, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'); // e.g., "aB3dE5fG7H"

--- a/stringFunctions/getFileExtension.ts
+++ b/stringFunctions/getFileExtension.ts
@@ -3,6 +3,11 @@
  *
  * @param filename - The filename to extract the extension from.
  * @returns The file extension, or an empty string if none exists.
+ *
+ * @example
+ * getFileExtension("example.txt"); // "txt"
+ * getFileExtension("example"); // ""
+ *
  */
 export function getFileExtension(filename: string): string {
   const lastDotIndex = filename.lastIndexOf('.');
@@ -16,6 +21,3 @@ export function getFileExtension(filename: string): string {
   return filename.substring(lastDotIndex + 1);
 }
 
-// Example usage:
-// getFileExtension("example.txt"); // "txt"
-// getFileExtension("example"); // ""

--- a/stringFunctions/hasLowercase.ts
+++ b/stringFunctions/hasLowercase.ts
@@ -3,11 +3,13 @@
  *
  * @param str - The string to check.
  * @returns True if the string contains lowercase letters, false otherwise.
+ *
+ * @example
+ * hasLowercase("Hello"); // true
+ * hasLowercase("HELLO"); // false
+ *
  */
 export function hasLowercase(str: string): boolean {
   return /[a-z]/.test(str);
 }
 
-// Example usage:
-// hasLowercase("Hello"); // true
-// hasLowercase("HELLO"); // false

--- a/stringFunctions/hasUppercase.ts
+++ b/stringFunctions/hasUppercase.ts
@@ -3,11 +3,13 @@
  *
  * @param str - The string to check.
  * @returns True if the string contains uppercase letters, false otherwise.
+ *
+ * @example
+ * hasUppercase("Hello"); // true
+ * hasUppercase("hello"); // false
+ *
  */
 export function hasUppercase(str: string): boolean {
   return /[A-Z]/.test(str);
 }
 
-// Example usage:
-// hasUppercase("Hello"); // true
-// hasUppercase("hello"); // false

--- a/stringFunctions/indexOfSubstring.ts
+++ b/stringFunctions/indexOfSubstring.ts
@@ -4,10 +4,12 @@
  * @param str - The string to search in.
  * @param substr - The substring to find.
  * @returns The index of the first occurrence, or -1 if not found.
+ *
+ * @example
+ * indexOfSubstring("hello world", "world"); // 6
+ *
  */
 export function indexOfSubstring(str: string, substr: string): number {
   return str.indexOf(substr);
 }
 
-// Example usage:
-// indexOfSubstring("hello world", "world"); // 6

--- a/stringFunctions/isAlpha.ts
+++ b/stringFunctions/isAlpha.ts
@@ -1,16 +1,20 @@
-// Example usage:
-// toSnakeCase("Hello World! How Are You?"); // "hello_world_how_are_you"
 
 /**
  * Checks if a string contains only alphabetical characters.
  *
  * @param str - The string to check.
  * @returns True if the string contains only letters, false otherwise.
+ *
+ * @example
+ * toSnakeCase("Hello World! How Are You?"); // "hello_world_how_are_you"
+ *
+ *
+ * @example
+ * isAlpha("Hello"); // true
+ * isAlpha("Hello123"); // false
+ *
  */
 export function isAlpha(str: string): boolean {
   return /^[A-Za-z]+$/.test(str);
 }
 
-// Example usage:
-// isAlpha("Hello"); // true
-// isAlpha("Hello123"); // false

--- a/stringFunctions/isAlphanumeric.ts
+++ b/stringFunctions/isAlphanumeric.ts
@@ -3,11 +3,13 @@
  *
  * @param str - The string to check.
  * @returns True if the string contains only alphanumeric characters, false otherwise.
+ *
+ * @example
+ * isAlphanumeric("Hello123"); // true
+ * isAlphanumeric("Hello!"); // false
+ *
  */
 export function isAlphanumeric(str: string): boolean {
   return /^[A-Za-z0-9]+$/.test(str);
 }
 
-// Example usage:
-// isAlphanumeric("Hello123"); // true
-// isAlphanumeric("Hello!"); // false

--- a/stringFunctions/isNumeric.ts
+++ b/stringFunctions/isNumeric.ts
@@ -3,11 +3,13 @@
  *
  * @param str - The string to check.
  * @returns True if the string contains only digits, false otherwise.
+ *
+ * @example
+ * isNumeric("12345"); // true
+ * isNumeric("123a5"); // false
+ *
  */
 export function isNumeric(str: string): boolean {
   return /^\d+$/.test(str);
 }
 
-// Example usage:
-// isNumeric("12345"); // true
-// isNumeric("123a5"); // false

--- a/stringFunctions/isPalindrome.ts
+++ b/stringFunctions/isPalindrome.ts
@@ -3,12 +3,14 @@
  *
  * @param str - The string to check.
  * @returns True if the string is a palindrome, false otherwise.
+ *
+ * @example
+ * isPalindrome("A man, a plan, a canal, Panama"); // true
+ * isPalindrome("hello"); // false
+ *
  */
 export function isPalindrome(str: string): boolean {
   const cleanedStr = str.replace(/[^A-Za-z0-9]/g, '').toLowerCase();
   return cleanedStr === cleanedStr.split('').reverse().join('');
 }
 
-// Example usage:
-// isPalindrome("A man, a plan, a canal, Panama"); // true
-// isPalindrome("hello"); // false

--- a/stringFunctions/isValidEmail.ts
+++ b/stringFunctions/isValidEmail.ts
@@ -3,12 +3,14 @@
  *
  * @param email - The string to check.
  * @returns True if the string is a valid email address, false otherwise.
+ *
+ * @example
+ * isValidEmail("test@example.com"); // true
+ * isValidEmail("invalid-email"); // false
+ *
  */
 export function isValidEmail(email: string): boolean {
   const emailRegex = /^[^\s@]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
   return emailRegex.test(email);
 }
 
-// Example usage:
-// isValidEmail("test@example.com"); // true
-// isValidEmail("invalid-email"); // false

--- a/stringFunctions/isWhitespace.ts
+++ b/stringFunctions/isWhitespace.ts
@@ -3,11 +3,13 @@
  *
  * @param str - The string to check.
  * @returns True if the string contains only whitespace characters, false otherwise.
+ *
+ * @example
+ * isWhitespace("   "); // true
+ * isWhitespace("Hello World"); // false
+ *
  */
 export function isWhitespace(str: string): boolean {
   return /^\s*$/.test(str);
 }
 
-// Example usage:
-// isWhitespace("   "); // true
-// isWhitespace("Hello World"); // false

--- a/stringFunctions/lastIndexOfSubstring.ts
+++ b/stringFunctions/lastIndexOfSubstring.ts
@@ -4,11 +4,13 @@
  * @param str - The string to search within.
  * @param substr - The substring to find.
  * @returns The index of the last occurrence of the substring, or -1 if not found.
+ *
+ * @example
+ * lastIndexOfSubstring("hello world world", "world"); // 12
+ * lastIndexOfSubstring("hello world", "foo"); // -1
+ *
  */
 export function lastIndexOfSubstring(str: string, substr: string): number {
   return str.lastIndexOf(substr);
 }
 
-// Example usage:
-// lastIndexOfSubstring("hello world world", "world"); // 12
-// lastIndexOfSubstring("hello world", "foo"); // -1

--- a/stringFunctions/padString.ts
+++ b/stringFunctions/padString.ts
@@ -6,6 +6,11 @@
  * @param padChar - The character to pad the string with.
  * @returns The padded string.
  * @throws An error if the target length is less than the string length or if padChar is not a single character.
+ *
+ * @example
+ * padString("hello", 10); // "  hello   "
+ * padString("hello", 10, '*'); // "**hello***"
+ *
  */
 export function padString(
   str: string,
@@ -27,6 +32,3 @@ export function padString(
 
   return padChar.repeat(padStartLength) + str + padChar.repeat(padEndLength);
 }
-// Example usage:
-// padString("hello", 10); // "  hello   "
-// padString("hello", 10, '*'); // "**hello***"

--- a/stringFunctions/removeWhitespace.ts
+++ b/stringFunctions/removeWhitespace.ts
@@ -3,10 +3,12 @@
  *
  * @param str - The string to process.
  * @returns The string with all whitespace removed.
+ *
+ * @example
+ * removeWhitespace("   hello   world   "); // "helloworld"
+ *
  */
 export function removeWhitespace(str: string): string {
   return str.replace(/\s+/g, '');
 }
 
-// Example usage:
-// removeWhitespace("   hello   world   "); // "helloworld"

--- a/stringFunctions/repeatString.ts
+++ b/stringFunctions/repeatString.ts
@@ -5,6 +5,10 @@
  * @param count - The number of times to repeat the string.
  * @returns The repeated string.
  * @throws Will throw an error if the count is not a number or is negative.
+ *
+ * @example
+ * repeatString("hello", 3); // "hellohellohello"
+ *
  */
 export function repeatString(str: string, count: number): string {
   if (isNaN(count)) {
@@ -16,5 +20,3 @@ export function repeatString(str: string, count: number): string {
   return str.repeat(count);
 }
 
-// Example usage:
-// repeatString("hello", 3); // "hellohellohello"

--- a/stringFunctions/repeatUntilLength.ts
+++ b/stringFunctions/repeatUntilLength.ts
@@ -5,6 +5,10 @@
  * @param length - The desired length of the output string.
  * @returns The repeated string truncated to the desired length.
  * @throws Will throw an error if the length is not a number or is negative.
+ *
+ * @example
+ * repeatUntilLength("abc", 10); // "abcabcabca"
+ *
  */
 export function repeatUntilLength(str: string, length: number): string {
   if (isNaN(length)) {
@@ -19,5 +23,3 @@ export function repeatUntilLength(str: string, length: number): string {
   return str.repeat(Math.ceil(length / str.length)).substring(0, length);
 }
 
-// Example usage:
-// repeatUntilLength("abc", 10); // "abcabcabca"

--- a/stringFunctions/replaceFirst.ts
+++ b/stringFunctions/replaceFirst.ts
@@ -5,6 +5,11 @@
  * @param searchValue - The substring to find.
  * @param replaceValue - The substring to replace with.
  * @returns The string with the first occurrence of the substring replaced.
+ *
+ * @example
+ * replaceFirst("hello world", "world", "everyone"); // "hello everyone"
+ * replaceFirst("hello world world", "world", "everyone"); // "hello everyone world"
+ *
  */
 export function replaceFirst(
   str: string,
@@ -21,6 +26,3 @@ export function replaceFirst(
   return str.replace(searchValue, replaceValue);
 }
 
-// Example usage:
-// replaceFirst("hello world", "world", "everyone"); // "hello everyone"
-// replaceFirst("hello world world", "world", "everyone"); // "hello everyone world"

--- a/stringFunctions/replaceMultiple.ts
+++ b/stringFunctions/replaceMultiple.ts
@@ -4,6 +4,11 @@
  * @param str - The string to search within.
  * @param replacements - An object where keys are substrings to find and values are substrings to replace with.
  * @returns The string with all specified substrings replaced.
+ *
+ * @example
+ * replaceMultiple("hello world", { "hello": "hi", "world": "everyone" }); // "hi everyone"
+ * replaceMultiple("foo bar baz", { "foo": "qux", "bar": "quux" }); // "qux quux baz"
+ *
  */
 export function replaceMultiple(
   str: string,
@@ -18,6 +23,3 @@ export function replaceMultiple(
   return str.replace(regex, (match) => replacements[match]);
 }
 
-// Example usage:
-// replaceMultiple("hello world", { "hello": "hi", "world": "everyone" }); // "hi everyone"
-// replaceMultiple("foo bar baz", { "foo": "qux", "bar": "quux" }); // "qux quux baz"

--- a/stringFunctions/replaceSubstring.ts
+++ b/stringFunctions/replaceSubstring.ts
@@ -5,6 +5,11 @@
  * @param searchValue - The substring to find.
  * @param replaceValue - The substring to replace with.
  * @returns The string with all occurrences of the substring replaced.
+ *
+ * @example
+ * replaceSubstring("hello world world", "world", "everyone"); // "hello everyone everyone"
+ * replaceSubstring("foo bar foo bar", "foo", "baz"); // "baz bar baz bar"
+ *
  */
 export function replaceSubstring(
   str: string,
@@ -21,6 +26,3 @@ export function replaceSubstring(
   return str.split(searchValue).join(replaceValue);
 }
 
-// Example usage:
-// replaceSubstring("hello world world", "world", "everyone"); // "hello everyone everyone"
-// replaceSubstring("foo bar foo bar", "foo", "baz"); // "baz bar baz bar"

--- a/stringFunctions/reverseString.ts
+++ b/stringFunctions/reverseString.ts
@@ -3,11 +3,13 @@
  *
  * @param str - The string to reverse.
  * @returns The reversed string.
+ *
+ * @example
+ * reverseString("hello"); // "olleh"
+ * reverseString("12345"); // "54321"
+ *
  */
 export function reverseString(str: string): string {
   return str.split('').reverse().join('');
 }
 
-// Example usage:
-// reverseString("hello"); // "olleh"
-// reverseString("12345"); // "54321"

--- a/stringFunctions/reverseWords.ts
+++ b/stringFunctions/reverseWords.ts
@@ -3,6 +3,12 @@
  *
  * @param str - The string to reverse the words in.
  * @returns The string with the words reversed and trailing white spaces removed.
+ *
+ * @example
+ * reverseWords("hello world"); // "world hello"
+ * reverseWords("The quick brown fox"); // "fox brown quick The"
+ * reverseWords("   "); // ""
+ *
  */
 export function reverseWords(str: string): string {
   if (!str.trim()) return '';
@@ -11,7 +17,3 @@ export function reverseWords(str: string): string {
   return str.trim().split(/\s+/).reverse().join(' ');
 }
 
-// Example usage:
-// reverseWords("hello world"); // "world hello"
-// reverseWords("The quick brown fox"); // "fox brown quick The"
-// reverseWords("   "); // ""

--- a/stringFunctions/slugify.ts
+++ b/stringFunctions/slugify.ts
@@ -3,6 +3,11 @@
  *
  * @param str - The string to convert.
  * @returns The slugified string.
+ *
+ * @example
+ * slugify("Hello World!"); // "hello-world"
+ * slugify("  This is a test.  "); // "this-is-a-test"
+ *
  */
 export function slugify(str: string): string {
   return str
@@ -13,6 +18,3 @@ export function slugify(str: string): string {
     .replace(/^-+|-+$/g, '');
 }
 
-// Example usage:
-// slugify("Hello World!"); // "hello-world"
-// slugify("  This is a test.  "); // "this-is-a-test"

--- a/stringFunctions/splitString.ts
+++ b/stringFunctions/splitString.ts
@@ -4,10 +4,12 @@
  * @param str - The string to split.
  * @param delimiter - The delimiter to use for splitting.
  * @returns An array of substrings.
+ *
+ * @example
+ * splitString("hello,world", ","); // ["hello", "world"]
+ *
  */
 export function splitString(str: string, delimiter: string): string[] {
   return str.split(delimiter);
 }
 
-// Example usage:
-// splitString("hello,world", ","); // ["hello", "world"]

--- a/stringFunctions/startsWith.ts
+++ b/stringFunctions/startsWith.ts
@@ -4,10 +4,12 @@
  * @param str - The string to check.
  * @param start - The substring to check for.
  * @returns True if the string starts with the substring, false otherwise.
+ *
+ * @example
+ * startsWith("hello world", "hello"); // true
+ *
  */
 export function startsWith(str: string, start: string): boolean {
   return str.startsWith(start);
 }
 
-// Example usage:
-// startsWith("hello world", "hello"); // true

--- a/stringFunctions/stringToBoolean.ts
+++ b/stringFunctions/stringToBoolean.ts
@@ -3,12 +3,14 @@
  *
  * @param str - The string to convert.
  * @returns The corresponding boolean value.
+ *
+ * @example
+ * stringToBoolean("true"); // true
+ * stringToBoolean("false"); // false
+ *
  */
 export function stringToBoolean(str: string): boolean {
   const normalizedStr = str.trim().toLowerCase();
   return normalizedStr === 'true' || normalizedStr === '1';
 }
 
-// Example usage:
-// stringToBoolean("true"); // true
-// stringToBoolean("false"); // false

--- a/stringFunctions/stringToNumber.ts
+++ b/stringFunctions/stringToNumber.ts
@@ -3,6 +3,11 @@
  *
  * @param str - The string to convert to a number.
  * @returns The converted number, or NaN if the string contains invalid characters.
+ *
+ * @example
+ * stringToNumber("123"); // 123
+ * stringToNumber("abc"); // NaN
+ *
  */
 export function stringToNumber(str: string): number {
   // Trim the input string to remove leading and trailing whitespace
@@ -18,6 +23,3 @@ export function stringToNumber(str: string): number {
   return NaN;
 }
 
-// Example usage:
-// stringToNumber("123"); // 123
-// stringToNumber("abc"); // NaN

--- a/stringFunctions/stringToWords.ts
+++ b/stringFunctions/stringToWords.ts
@@ -3,6 +3,10 @@
  *
  * @param str - The string to split into words.
  * @returns An array of words.
+ *
+ * @example
+ * stringToWords("Hello world!"); // ["Hello", "world!"]
+ *
  */
 export function stringToWords(str: string): string[] {
   return str
@@ -11,5 +15,3 @@ export function stringToWords(str: string): string[] {
     .filter((word) => word.length > 0); // Filter out empty strings
 }
 
-// Example usage:
-// stringToWords("Hello world!"); // ["Hello", "world!"]

--- a/stringFunctions/stripHtmlTags.ts
+++ b/stringFunctions/stripHtmlTags.ts
@@ -3,10 +3,12 @@
  *
  * @param str - The string to process.
  * @returns The string with HTML tags removed.
+ *
+ * @example
+ * stripHtmlTags("<p>Hello <b>world</b></p>"); // "Hello world"
+ *
  */
 export function stripHtmlTags(str: string): string {
   return str.replace(/<\/?[^>]+(>|$)/g, '');
 }
 
-// Example usage:
-// stripHtmlTags("<p>Hello <b>world</b></p>"); // "Hello world"

--- a/stringFunctions/toKebabCase.ts
+++ b/stringFunctions/toKebabCase.ts
@@ -3,6 +3,10 @@
  *
  * @param str - The string to convert.
  * @returns The kebab-cased string.
+ *
+ * @example
+ * toKebabCase("Hello World! How Are You?"); // "hello-world-how-are-you"
+ *
  */
 export function toKebabCase(str: string): string {
   return str
@@ -14,5 +18,3 @@ export function toKebabCase(str: string): string {
     .replace(/^-+|-+$/g, ''); // Trim hyphens from start and end
 }
 
-// Example usage:
-// toKebabCase("Hello World! How Are You?"); // "hello-world-how-are-you"

--- a/stringFunctions/toLowerCase.ts
+++ b/stringFunctions/toLowerCase.ts
@@ -3,10 +3,12 @@
  *
  * @param str - The string to convert.
  * @returns The lowercase string.
+ *
+ * @example
+ * toLowerCase("Hello World"); // "hello world"
+ *
  */
 export function toLowerCase(str: string): string {
   return str.toLowerCase();
 }
 
-// Example usage:
-// toLowerCase("Hello World"); // "hello world"

--- a/stringFunctions/toSnakeCase.ts
+++ b/stringFunctions/toSnakeCase.ts
@@ -3,6 +3,10 @@
  *
  * @param str - The string to convert.
  * @returns The snake-cased string.
+ *
+ * @example
+ * toSnakeCase("Hello World! How Are You?"); // "hello_world_how_are_you"
+ *
  */
 export function toSnakeCase(str: string): string {
   return str
@@ -14,5 +18,3 @@ export function toSnakeCase(str: string): string {
     .replace(/^_+|_+$/g, ''); // Trim underscores from start and end
 }
 
-// Example usage:
-// toSnakeCase("Hello World! How Are You?"); // "hello_world_how_are_you"

--- a/stringFunctions/toUpperCase.ts
+++ b/stringFunctions/toUpperCase.ts
@@ -3,10 +3,12 @@
  *
  * @param str - The string to convert.
  * @returns The uppercase string.
+ *
+ * @example
+ * toUpperCase("Hello World"); // "HELLO WORLD"
+ *
  */
 export function toUpperCase(str: string): string {
   return str.toUpperCase();
 }
 
-// Example usage:
-// toUpperCase("Hello World"); // "HELLO WORLD"

--- a/stringFunctions/trimWhitespace.ts
+++ b/stringFunctions/trimWhitespace.ts
@@ -3,10 +3,12 @@
  *
  * @param str - The string to trim.
  * @returns The trimmed string.
+ *
+ * @example
+ * trimWhitespace("   hello   "); // "hello"
+ *
  */
 export function trimWhitespace(str: string): string {
   return str.trim();
 }
 
-// Example usage:
-// trimWhitespace("   hello   "); // "hello"

--- a/stringFunctions/truncateString.ts
+++ b/stringFunctions/truncateString.ts
@@ -4,6 +4,10 @@
  * @param str - The string to truncate.
  * @param maxLength - The maximum length of the resulting string.
  * @returns The truncated string with an ellipsis if necessary.
+ *
+ * @example
+ * truncateString("This is a long string that needs to be truncated.", 20); // "This is a long st..."
+ *
  */
 export function truncateString(str: string, maxLength: number): string {
   if (maxLength <= 0) return '';
@@ -12,5 +16,3 @@ export function truncateString(str: string, maxLength: number): string {
   return str.slice(0, maxLength - 3) + '...';
 }
 
-// Example usage:
-// truncateString("This is a long string that needs to be truncated.", 20); // "This is a long st..."

--- a/stringFunctions/uniqueCharacters.ts
+++ b/stringFunctions/uniqueCharacters.ts
@@ -3,10 +3,12 @@
  *
  * @param str - The string to analyze.
  * @returns An array of unique characters.
+ *
+ * @example
+ * uniqueCharacters("hello"); // ['h', 'e', 'l', 'o']
+ *
  */
 export function uniqueCharacters(str: string): string[] {
   return Array.from(new Set(str));
 }
 
-// Example usage:
-// uniqueCharacters("hello"); // ['h', 'e', 'l', 'o']

--- a/stringFunctions/wordsToSentence.ts
+++ b/stringFunctions/wordsToSentence.ts
@@ -3,6 +3,12 @@
  *
  * @param words - The array of words to join.
  * @returns The joined sentence.
+ *
+ * @example
+ * wordsToSentence(["Hello", "world!"]); // "Hello world!"
+ * wordsToSentence([]); // ""
+ * wordsToSentence(["Hello", "", "world!"]); // "Hello world!"
+ *
  */
 export function wordsToSentence(words: string[]): string {
   if (!Array.isArray(words) || words.length === 0) {
@@ -14,7 +20,3 @@ export function wordsToSentence(words: string[]): string {
     .join(' ');
 }
 
-// Example usage:
-// wordsToSentence(["Hello", "world!"]); // "Hello world!"
-// wordsToSentence([]); // ""
-// wordsToSentence(["Hello", "", "world!"]); // "Hello world!"

--- a/utilityFunctions/bytesToSize.ts
+++ b/utilityFunctions/bytesToSize.ts
@@ -3,6 +3,11 @@
  *
  * @param bytes - The number of bytes.
  * @returns The size as a string with appropriate units.
+ *
+ * @example
+ * bytesToSize(1024); // "1.00 KB"
+ * bytesToSize(1048576); // "1.00 MB"
+ *
  */
 export function bytesToSize(bytes: number): string {
   const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
@@ -11,6 +16,3 @@ export function bytesToSize(bytes: number): string {
   return `${(bytes / Math.pow(1024, i)).toFixed(2)} ${sizes[i]}`;
 }
 
-// Example usage:
-// bytesToSize(1024); // "1.00 KB"
-// bytesToSize(1048576); // "1.00 MB"

--- a/utilityFunctions/debounce.ts
+++ b/utilityFunctions/debounce.ts
@@ -4,6 +4,11 @@
  * @param func - The function to debounce.
  * @param delay - The debounce delay in milliseconds.
  * @returns A debounced version of the function.
+ *
+ * @example
+ * const debouncedFunction = debounce(() => console.log('Debounced!'), 300);
+ * debouncedFunction(); // Only executed after 300ms if not called again in that time
+ *
  */
 export function debounce<T extends (...args: any[]) => any>(
   func: T,
@@ -16,6 +21,3 @@ export function debounce<T extends (...args: any[]) => any>(
   };
 }
 
-// Example usage:
-// const debouncedFunction = debounce(() => console.log('Debounced!'), 300);
-// debouncedFunction(); // Only executed after 300ms if not called again in that time

--- a/utilityFunctions/debounceAsync.ts
+++ b/utilityFunctions/debounceAsync.ts
@@ -4,6 +4,11 @@
  * @param func - The async function to debounce.
  * @param wait - The debounce delay in milliseconds.
  * @returns A debounced version of the function.
+ *
+ * @example
+ * const fetchDebounced = debounceAsync(fetchData, 300);
+ * fetchDebounced(); // Only calls after 300ms of inactivity
+ *
  */
 export function debounceAsync<T extends (...args: any[]) => Promise<any>>(
   func: T,
@@ -19,6 +24,3 @@ export function debounceAsync<T extends (...args: any[]) => Promise<any>>(
     });
 }
 
-// Example usage:
-// const fetchDebounced = debounceAsync(fetchData, 300);
-// fetchDebounced(); // Only calls after 300ms of inactivity

--- a/utilityFunctions/delay.ts
+++ b/utilityFunctions/delay.ts
@@ -3,10 +3,12 @@
  *
  * @param ms - The delay in milliseconds.
  * @returns A promise that resolves after the delay.
+ *
+ * @example
+ * delay(2000).then(() => console.log("Waited 2 seconds"));
+ *
  */
 export function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-// Example usage:
-// delay(2000).then(() => console.log("Waited 2 seconds"));

--- a/utilityFunctions/hexToRgb.ts
+++ b/utilityFunctions/hexToRgb.ts
@@ -3,6 +3,10 @@
  *
  * @param hex - The hex color string.
  * @returns An object with red, green, and blue values.
+ *
+ * @example
+ * hexToRgb('#ff5733'); // { r: 255, g: 87, b: 51 }
+ *
  */
 export function hexToRgb(
   hex: string,
@@ -18,5 +22,3 @@ export function hexToRgb(
   return { r, g, b };
 }
 
-// Example usage:
-// hexToRgb('#ff5733'); // { r: 255, g: 87, b: 51 }

--- a/utilityFunctions/isNil.ts
+++ b/utilityFunctions/isNil.ts
@@ -3,12 +3,14 @@
  *
  * @param value - The value to check.
  * @returns True if the value is null or undefined, false otherwise.
+ *
+ * @example
+ * isNil(null); // true
+ * isNil(undefined); // true
+ * isNil(0); // false
+ *
  */
 export function isNil(value: any): boolean {
   return value === null || value === undefined;
 }
 
-// Example usage:
-// isNil(null); // true
-// isNil(undefined); // true
-// isNil(0); // false

--- a/utilityFunctions/parseQueryString.ts
+++ b/utilityFunctions/parseQueryString.ts
@@ -3,6 +3,10 @@
  *
  * @param queryString - The query string to parse.
  * @returns An object representing the query parameters.
+ *
+ * @example
+ * parseQueryString('?name=John&age=30'); // { name: "John", age: "30" }
+ *
  */
 export function parseQueryString(queryString: string): Record<string, string> {
   if (!queryString || queryString === '?') {
@@ -23,5 +27,3 @@ export function parseQueryString(queryString: string): Record<string, string> {
     );
 }
 
-// Example usage:
-// parseQueryString('?name=John&age=30'); // { name: "John", age: "30" }

--- a/utilityFunctions/rgbToHex.ts
+++ b/utilityFunctions/rgbToHex.ts
@@ -3,11 +3,13 @@
  *
  * @param rgb - The object containing red, green, and blue values.
  * @returns The hex color string.
+ *
+ * @example
+ * rgbToHex({ r: 255, g: 87, b: 51 }); // "#ff5733"
+ *
  */
 export function rgbToHex(rgb: { r: number; g: number; b: number }): string {
   const toHex = (num: number) => num.toString(16).padStart(2, '0');
   return `#${toHex(rgb.r)}${toHex(rgb.g)}${toHex(rgb.b)}`;
 }
 
-// Example usage:
-// rgbToHex({ r: 255, g: 87, b: 51 }); // "#ff5733"

--- a/utilityFunctions/safeJSONParse.ts
+++ b/utilityFunctions/safeJSONParse.ts
@@ -4,6 +4,11 @@
  * @param jsonString - The JSON string to parse.
  * @param defaultValue - The default value to return if parsing fails.
  * @returns The parsed object, or the default value if parsing fails.
+ *
+ * @example
+ * safeJSONParse('{"name":"John"}', {}); // { name: "John" }
+ * safeJSONParse('Invalid JSON', {}); // {}
+ *
  */
 export function safeJSONParse<T>(jsonString: string, defaultValue: T): T {
   try {
@@ -13,6 +18,3 @@ export function safeJSONParse<T>(jsonString: string, defaultValue: T): T {
   }
 }
 
-// Example usage:
-// safeJSONParse('{"name":"John"}', {}); // { name: "John" }
-// safeJSONParse('Invalid JSON', {}); // {}

--- a/utilityFunctions/throttle.ts
+++ b/utilityFunctions/throttle.ts
@@ -4,6 +4,11 @@
  * @param func - The function to throttle.
  * @param limit - The time interval in milliseconds.
  * @returns A throttled version of the function.
+ *
+ * @example
+ * const throttledLog = throttle(() => console.log("Throttled!"), 1000);
+ * throttledLog(); // Logs at most once every second
+ *
  */
 export function throttle<T extends (...args: any[]) => void>(
   func: T,
@@ -29,6 +34,3 @@ export function throttle<T extends (...args: any[]) => void>(
   };
 }
 
-// Example usage:
-// const throttledLog = throttle(() => console.log("Throttled!"), 1000);
-// throttledLog(); // Logs at most once every second


### PR DESCRIPTION
## Summary
- move all example usage comments into `@example` blocks
- ensure docs show basic usage inline with function descriptions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d4e656948832596106efebc3354e4