### PR TITLE
Add TypeScript build config

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
         "test:local": "jest --config jest.local.config.ts",
         "lint": "eslint . --ext .ts",
         "lint:fix": "eslint . --ext .ts --fix",
-        "format": "prettier --write \"**/*.{ts,js,json,md}\""
+        "format": "prettier --write \"**/*.{ts,js,json,md}\"",
+        "build": "tsc"
     },
     "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "types": ["node", "jest"],
-    "lib": ["es2023", "dom"]
+    "lib": ["es2023", "dom"],
+    "outDir": "dist"
   }
 }


### PR DESCRIPTION
## Summary
- add `outDir` to TypeScript compiler options
- add a build script that runs `tsc`
- confirm `dist/` is ignored

## Testing
- `npm run test:local`


------
https://chatgpt.com/codex/tasks/task_e_68711ccabe7c83258df8f45ddb6832b6