### PR TITLE
Add alias for object groupBy export

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import { chunkArray, deepMerge } from 'ts-functions-library';
 The main folders group functions by purpose:
 
 - **arrayFunctions** – helpers for arrays such as `chunkArray`, `flattenArray`, and `mergeUnique`.
-- **objectFunctions** – utilities for manipulating objects including `deepMerge`, `safeGet`, and `groupBy`.
+- **objectFunctions** – utilities for manipulating objects including `deepMerge`, `safeGet`, and `groupByObject`.
 - **stringFunctions** – text related helpers like `slugify`, `trimWhitespace`, and `isValidEmail`.
 - **dateFunctions** – date utilities such as `formatDate`, `addMonths`, and `getWeekNumber`.
 - **encodingFunctions** – simple Base64 encoding/decoding helpers.

--- a/index.ts
+++ b/index.ts
@@ -108,7 +108,7 @@ export * from './objectFunctions/flipObject';
 export * from './objectFunctions/fromDotNotation';
 export * from './objectFunctions/getDeepEqualityHash';
 export * from './objectFunctions/getObjectDifference';
-export * from './objectFunctions/groupBy';
+export { groupBy as groupByObject } from './objectFunctions/groupBy';
 export * from './objectFunctions/hasKey';
 export * from './objectFunctions/invertObject';
 export * from './objectFunctions/isDeepSubset';


### PR DESCRIPTION
## Summary
- alias `groupBy` from objectFunctions as `groupByObject`
- document new alias in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68728b3fcc0c8325b4fc0bfd2d1bc974