### PR TITLE
Fix debounce this type

### DIFF
--- a/utilityFunctions/debounce.ts
+++ b/utilityFunctions/debounce.ts
@@ -21,7 +21,7 @@ export function debounce<T extends (...args: any[]) => any>(
   delay: number,
 ): (...args: Parameters<T>) => void {
   let timeoutId: ReturnType<typeof setTimeout>;
-  return function (...args: Parameters<T>) {
+  return function (this: unknown, ...args: Parameters<T>) {
     clearTimeout(timeoutId);
     timeoutId = setTimeout(() => func.apply(this, args), delay);
   };


### PR DESCRIPTION
## Summary
- specify the `this` parameter type in `debounce`

## Testing
- `npx tsc --noEmit`
- `npm run test:local`


------
https://chatgpt.com/codex/tasks/task_e_68728b4d424c832588b08e2ea702e103