### PR TITLE
Use generics in array helpers

### DIFF
--- a/arrayFunctions/cartesianProduct.ts
+++ b/arrayFunctions/cartesianProduct.ts
@@ -35,14 +35,19 @@
  *
  * @complexity O(n^m) where n is the average array length and m is the number of arrays
  */
-export function cartesianProduct(...arrays: any[][]): any[][] {
+type CartesianTuple<T extends any[][]> = { [K in keyof T]: T[K][number] };
+
+export function cartesianProduct<T extends any[][]>(
+  ...arrays: T
+): CartesianTuple<T>[] {
   // Handle empty array case
   if (arrays.some((arr) => arr.length === 0)) {
     return [];
   }
 
-  return arrays.reduce<any[][]>(
-    (acc, arr) => acc.flatMap((x) => arr.map((y) => [...x, y])),
-    [[]] as any[][],
+  return arrays.reduce<CartesianTuple<T>[]>(
+    (acc, arr) =>
+      acc.flatMap((x) => arr.map((y) => [...x, y] as CartesianTuple<T>)),
+    [[]] as unknown as CartesianTuple<T>[],
   );
 }

--- a/arrayFunctions/zipMultiple.ts
+++ b/arrayFunctions/zipMultiple.ts
@@ -36,11 +36,13 @@
  *
  * @complexity O(n*m) where n is the length of the shortest array and m is the number of arrays
  */
-export function zipMultiple(...arrays: any[][]): any[][] {
+type ZippedTuple<T extends any[][]> = { [K in keyof T]: T[K][number] };
+
+export function zipMultiple<T extends any[][]>(...arrays: T): ZippedTuple<T>[] {
   const minLength = Math.min(...arrays.map((arr) => arr.length));
-  const result: any[][] = [];
+  const result: ZippedTuple<T>[] = [];
   for (let i = 0; i < minLength; i++) {
-    result.push(arrays.map((arr) => arr[i]));
+    result.push(arrays.map((arr) => arr[i]) as ZippedTuple<T>);
   }
   return result;
 }


### PR DESCRIPTION
## Summary
- support tuple type inference for `cartesianProduct`
- add tuple-preserving generics to `zipMultiple`

## Testing
- `npm run test:local`

------
https://chatgpt.com/codex/tasks/task_e_68728b4f0b5c8325be2e8312a87fc177