### PR TITLE
Use local binaries in test scripts

### DIFF
--- a/run-tests-github.sh
+++ b/run-tests-github.sh
@@ -7,6 +7,10 @@ log_with_time() {
 
 log_with_time "[INFO] Starting test execution script"
 
+# Ensure local node binaries are available
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export PATH="$SCRIPT_DIR/node_modules/.bin:$PATH"
+
 # Print the current local time
 log_with_time "[INFO] Current local time: $(date)"
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -8,6 +8,10 @@ log_with_time() {
 
 log_with_time "[INFO] Running tests"
 
+# Ensure local node binaries are available
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export PATH="$SCRIPT_DIR/node_modules/.bin:$PATH"
+
 # Print the current local time
 log_with_time "[INFO] Current local time: $(date)"
 


### PR DESCRIPTION
## Summary
- ensure scripts use local node binaries by prepending `node_modules/.bin` to `PATH`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68737bea3540832592d4f207628e600c