### PR TITLE
Refactor object function types

### DIFF
--- a/objectFunctions/deepEqual.ts
+++ b/objectFunctions/deepEqual.ts
@@ -13,7 +13,7 @@
  * @note Handles primitive types, objects, arrays, NaN, Dates, and RegExp objects.
  * Does not support Maps, Sets, or detecting circular references.
  */
-export function deepEqual(a: any, b: any): boolean {
+export function deepEqual(a: unknown, b: unknown): boolean {
   // Special case for NaN
   if (typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b)) {
     return true;
@@ -56,8 +56,10 @@ export function deepEqual(a: any, b: any): boolean {
   }
 
   // Get the keys of both objects.
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
+  const objA = a as Record<string, unknown>;
+  const objB = b as Record<string, unknown>;
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
 
   // If the objects have different numbers of keys, they are not deeply equal.
   if (keysA.length !== keysB.length) return false;
@@ -65,7 +67,7 @@ export function deepEqual(a: any, b: any): boolean {
   // Recursively compare each key and value in both objects.
   for (const key of keysA) {
     // If the key is not present in both objects or the values are not deeply equal, return false.
-    if (!keysB.includes(key) || !deepEqual(a[key], b[key])) {
+    if (!keysB.includes(key) || !deepEqual(objA[key], objB[key])) {
       return false;
     }
   }

--- a/objectFunctions/entriesToObject.ts
+++ b/objectFunctions/entriesToObject.ts
@@ -16,7 +16,7 @@
  * const result = entriesToObject(mixed);
  * // => { id: 1, active: true, data: { count: 5 } }
  */
-export function entriesToObject<T>(entries: [string, any][]): T {
+export function entriesToObject<T>(entries: [string, unknown][]): T {
   if (!Array.isArray(entries)) {
     throw new TypeError('Input must be an array of key-value pairs');
   }

--- a/objectFunctions/getDeepEqualityHash.ts
+++ b/objectFunctions/getDeepEqualityHash.ts
@@ -16,7 +16,7 @@
  * and circular references are not supported.
  * @note Collision is possible, though unlikely for typical objects.
  */
-export function getDeepEqualityHash(obj: any): number {
+export function getDeepEqualityHash(obj: unknown): number {
   if (typeof obj !== 'object' || obj === null) {
     throw new TypeError('Input must be a non-null object');
   }

--- a/objectFunctions/keysToCamelCase.ts
+++ b/objectFunctions/keysToCamelCase.ts
@@ -14,14 +14,16 @@
  * @note Converts both snake_case and kebab-case to camelCase.
  * @note Creates a new object/array and does not modify the original.
  */
-export function keysToCamelCase(obj: any): any {
+export function keysToCamelCase(
+  obj: Record<string, unknown> | unknown[],
+): Record<string, unknown> | unknown[] {
   if (obj === null || typeof obj !== 'object') {
     throw new TypeError('Input must be a non-null object');
   }
 
-  const transform = (value: any): any => {
+  const transform = <T>(value: T): T => {
     if (Array.isArray(value)) {
-      return value.map(transform);
+      return value.map((v) => transform(v)) as unknown as T;
     }
     if (value !== null && typeof value === 'object') {
       return Object.fromEntries(
@@ -33,7 +35,7 @@ export function keysToCamelCase(obj: any): any {
             : k,
           transform(v),
         ]),
-      );
+      ) as unknown as T;
     }
     return value;
   };

--- a/objectFunctions/keysToSnakeCase.ts
+++ b/objectFunctions/keysToSnakeCase.ts
@@ -14,14 +14,16 @@
  * @note Creates a new object/array and does not modify the original.
  * @note Properly handles acronyms and multiple capital letters.
  */
-export function keysToSnakeCase(obj: any): any {
+export function keysToSnakeCase(
+  obj: Record<string, unknown> | unknown[],
+): Record<string, unknown> | unknown[] {
   if (obj === null || typeof obj !== 'object') {
     throw new TypeError('Input must be a non-null object');
   }
 
-  const transform = (value: any): any => {
+  const transform = <T>(value: T): T => {
     if (Array.isArray(value)) {
-      return value.map(transform);
+      return value.map((v) => transform(v)) as unknown as T;
     }
     if (value !== null && typeof value === 'object') {
       return Object.fromEntries(
@@ -31,7 +33,7 @@ export function keysToSnakeCase(obj: any): any {
             : k,
           transform(v),
         ]),
-      );
+      ) as unknown as T;
     }
     return value;
   };

--- a/objectFunctions/safeGet.ts
+++ b/objectFunctions/safeGet.ts
@@ -16,32 +16,40 @@
  * @note Returns the default value if any segment of the path doesn't exist.
  * @note Only supports dot notation and doesn't handle array indices.
  */
-export function safeGet<T>(
+export function safeGet<T extends Record<string, unknown>, D>(
   obj: T,
   path: string,
-  defaultValue: any = undefined,
-): any {
+  defaultValue: D = undefined as unknown as D,
+): D | unknown {
   if (typeof obj !== 'object' || obj === null) {
     throw new TypeError('Input must be a non-null object');
   }
   if (path === '') return obj;
-  if (Object.prototype.hasOwnProperty.call(obj as any, path)) {
-    return (obj as any)[path];
+  if (Object.prototype.hasOwnProperty.call(obj, path)) {
+    return obj[path];
   }
 
   const parts = path.split('.');
   if (parts.slice(1, -1).some((p) => p === '')) return defaultValue;
   const keys = parts.filter((k) => k);
-  let current: any = obj;
+  let current: unknown = obj;
   for (let i = 0; i < keys.length; i++) {
     if (current == null) return defaultValue;
     const key = keys[i];
-    if (Object.prototype.hasOwnProperty.call(current, key)) {
-      current = current[key];
+    if (
+      typeof current === 'object' &&
+      current !== null &&
+      Object.prototype.hasOwnProperty.call(current, key)
+    ) {
+      current = (current as Record<string, unknown>)[key];
     } else {
       const rest = keys.slice(i).join('.');
-      if (Object.prototype.hasOwnProperty.call(current, rest)) {
-        return current[rest];
+      if (
+        typeof current === 'object' &&
+        current !== null &&
+        Object.prototype.hasOwnProperty.call(current, rest)
+      ) {
+        return (current as Record<string, unknown>)[rest];
       }
       return defaultValue;
     }

--- a/objectFunctions/safeSet.ts
+++ b/objectFunctions/safeSet.ts
@@ -17,33 +17,33 @@
  * @note Creates empty objects for any missing intermediate properties.
  * @note Only supports dot notation and doesn't handle array indices.
  */
-export function safeSet<T extends Record<string, any>>(
+export function safeSet<T extends Record<string, unknown>, V>(
   obj: T,
   path: string,
-  value: any,
+  value: V,
 ): void {
   if (typeof obj !== 'object' || obj === null) {
     throw new TypeError('Input must be a non-null object');
   }
   if (path === '') return;
   if (Object.prototype.hasOwnProperty.call(obj, path)) {
-    (obj as any)[path] = value;
+    (obj as Record<string, unknown>)[path] = value as unknown;
     return;
   }
 
   const keys = path.split('.').filter((k) => k);
-  let current: any = obj;
+  let current: Record<string, unknown> = obj;
   for (let i = 0; i < keys.length - 1; i++) {
     const key = keys[i];
     const rest = keys.slice(i).join('.');
     if (Object.prototype.hasOwnProperty.call(current, rest)) {
-      current[rest] = value;
+      (current as Record<string, unknown>)[rest] = value as unknown;
       return;
     }
     if (!current[key] || typeof current[key] !== 'object') {
       current[key] = {};
     }
-    current = current[key];
+    current = current[key] as Record<string, unknown>;
   }
-  current[keys[keys.length - 1]] = value;
+  (current as Record<string, unknown>)[keys[keys.length - 1]] = value as unknown;
 }

--- a/objectFunctions/unflattenObject.ts
+++ b/objectFunctions/unflattenObject.ts
@@ -39,28 +39,28 @@ export function unflattenObject(
 
       if (isLast) {
         if (isIndex) {
-          if (!Array.isArray(current)) current = [];
+          if (!Array.isArray(current)) {
+            current = [];
+          }
           (current as unknown[])[Number(part)] = value;
         } else {
           (current as Record<string, unknown>)[part] = value;
         }
-      } else {
-        if (isIndex) {
-          if (!Array.isArray((current as any)[Number(part)])) {
-            (current as any)[Number(part)] = nextIsIndex ? [] : {};
-          }
-          current = (current as any)[Number(part)];
-        } else {
-          if (
-            !(current as Record<string, unknown>)[part] ||
-            typeof (current as Record<string, unknown>)[part] !== 'object'
-          ) {
-            (current as Record<string, unknown>)[part] = nextIsIndex ? [] : {};
-          }
-          current = (current as any)[part] as
-            | Record<string, unknown>
-            | unknown[];
+      } else if (isIndex) {
+        if (!Array.isArray(current)) {
+          current = [];
         }
+        const arr = current as unknown[];
+        if (!arr[Number(part)] || typeof arr[Number(part)] !== 'object') {
+          arr[Number(part)] = nextIsIndex ? [] : {};
+        }
+        current = arr[Number(part)] as Record<string, unknown> | unknown[];
+      } else {
+        const objRef = current as Record<string, unknown>;
+        if (!objRef[part] || typeof objRef[part] !== 'object') {
+          objRef[part] = nextIsIndex ? [] : {};
+        }
+        current = objRef[part] as Record<string, unknown> | unknown[];
       }
     });
   }


### PR DESCRIPTION
## Summary
- improve typings for `safeSet` and `safeGet`
- remove casts and tighten types in `unflattenObject`
- make key conversion helpers generic
- use `unknown` in `deepEqual`, `getDeepEqualityHash`, and `entriesToObject`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e028888688325835dc092001c2c67