### PR TITLE
Update object utility typings

### DIFF
--- a/functionsUnittests/objectFunctions/hasKey.test.ts
+++ b/functionsUnittests/objectFunctions/hasKey.test.ts
@@ -32,14 +32,20 @@ describe('hasKey', () => {
   // Test case 5: Check if an array has a key
   it('5. should return true if an array has the key', () => {
     const arr = [1, 2, 3];
-    const result = hasKey(arr, '0');
+    const result = hasKey(
+      arr as unknown as Record<string, unknown>,
+      '0',
+    );
     expect(result).toBe(true);
   });
 
   // Test case 6: Check if an array does not have a key
   it('6. should return false if an array does not have the key', () => {
     const arr = [1, 2, 3];
-    const result = hasKey(arr, '3');
+    const result = hasKey(
+      arr as unknown as Record<string, unknown>,
+      '3',
+    );
     expect(result).toBe(false);
   });
 

--- a/functionsUnittests/objectFunctions/isObjectEmpty.test.ts
+++ b/functionsUnittests/objectFunctions/isObjectEmpty.test.ts
@@ -25,7 +25,9 @@ describe('isObjectEmpty', () => {
   // Test case 4: Check if an array is empty
   it('4. should return false for an array', () => {
     const arr = [1, 2, 3];
-    const result = isObjectEmpty(arr);
+    const result = isObjectEmpty(
+      arr as unknown as Record<string, unknown>,
+    );
     expect(result).toBe(false);
   });
 

--- a/functionsUnittests/objectFunctions/objectSize.test.ts
+++ b/functionsUnittests/objectFunctions/objectSize.test.ts
@@ -44,7 +44,7 @@ describe('objectSize', () => {
   // Test case 5: Handle arrays as objects
   it('5. should return the correct size for an array', () => {
     const arr = [1, 2, 3];
-    const result = objectSize(arr);
+    const result = objectSize(arr as unknown as Record<string, unknown>);
     const expected = 3;
     expect(result).toBe(expected);
   });

--- a/functionsUnittests/objectFunctions/omitBy.test.ts
+++ b/functionsUnittests/objectFunctions/omitBy.test.ts
@@ -4,7 +4,7 @@ describe('omitBy', () => {
   // Test case 1: Omit properties based on value
   it('Test case 1: should omit properties based on value', () => {
     const obj = { a: 1, b: 2, c: 3 };
-    const result = omitBy(obj, (value) => value > 1);
+    const result = omitBy(obj, (value) => (value as number) > 1);
     const expected = { a: 1 };
     expect(result).toEqual(expected);
   });
@@ -60,26 +60,36 @@ describe('omitBy', () => {
 
   // Test case 8: Handle non-object input (number)
   it('Test case 8: should throw a TypeError if input is a number', () => {
-    expect(() => omitBy(42 as any, (value) => value)).toThrow(TypeError);
+    expect(() => omitBy(42 as any, (value) => Boolean(value))).toThrow(
+      TypeError,
+    );
   });
 
   // Test case 9: Handle non-object input (string)
   it('Test case 9: should throw a TypeError if input is a string', () => {
-    expect(() => omitBy('string' as any, (value) => value)).toThrow(TypeError);
+    expect(() =>
+      omitBy('string' as any, (value) => Boolean(value)),
+    ).toThrow(TypeError);
   });
 
   // Test case 10: Handle non-object input (boolean)
   it('Test case 10: should throw a TypeError if input is a boolean', () => {
-    expect(() => omitBy(true as any, (value) => value)).toThrow(TypeError);
+    expect(() => omitBy(true as any, (value) => Boolean(value))).toThrow(
+      TypeError,
+    );
   });
 
   // Test case 11: Handle null input
   it('Test case 11: should throw a TypeError if input is null', () => {
-    expect(() => omitBy(null as any, (value) => value)).toThrow(TypeError);
+    expect(() => omitBy(null as any, (value) => Boolean(value))).toThrow(
+      TypeError,
+    );
   });
 
   // Test case 12: Handle undefined input
   it('Test case 12: should throw a TypeError if input is undefined', () => {
-    expect(() => omitBy(undefined as any, (value) => value)).toThrow(TypeError);
+    expect(() =>
+      omitBy(undefined as any, (value) => Boolean(value)),
+    ).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/pickBy.test.ts
+++ b/functionsUnittests/objectFunctions/pickBy.test.ts
@@ -4,7 +4,7 @@ describe('pickBy', () => {
   // Test case 1: Pick properties based on value
   it('Test case 1: should pick properties based on value', () => {
     const obj = { a: 1, b: 2, c: 3 };
-    const result = pickBy(obj, (value) => value > 1);
+    const result = pickBy(obj, (value) => (value as number) > 1);
     const expected = { b: 2, c: 3 };
     expect(result).toEqual(expected);
   });
@@ -60,26 +60,36 @@ describe('pickBy', () => {
 
   // Test case 8: Handle non-object input (number)
   it('Test case 8: should throw a TypeError if input is a number', () => {
-    expect(() => pickBy(42 as any, (value) => value)).toThrow(TypeError);
+    expect(() => pickBy(42 as any, (value) => Boolean(value))).toThrow(
+      TypeError,
+    );
   });
 
   // Test case 9: Handle non-object input (string)
   it('Test case 9: should throw a TypeError if input is a string', () => {
-    expect(() => pickBy('string' as any, (value) => value)).toThrow(TypeError);
+    expect(() =>
+      pickBy('string' as any, (value) => Boolean(value)),
+    ).toThrow(TypeError);
   });
 
   // Test case 10: Handle non-object input (boolean)
   it('Test case 10: should throw a TypeError if input is a boolean', () => {
-    expect(() => pickBy(true as any, (value) => value)).toThrow(TypeError);
+    expect(() => pickBy(true as any, (value) => Boolean(value))).toThrow(
+      TypeError,
+    );
   });
 
   // Test case 11: Handle null input
   it('Test case 11: should throw a TypeError if input is null', () => {
-    expect(() => pickBy(null as any, (value) => value)).toThrow(TypeError);
+    expect(() => pickBy(null as any, (value) => Boolean(value))).toThrow(
+      TypeError,
+    );
   });
 
   // Test case 12: Handle undefined input
   it('Test case 12: should throw a TypeError if input is undefined', () => {
-    expect(() => pickBy(undefined as any, (value) => value)).toThrow(TypeError);
+    expect(() =>
+      pickBy(undefined as any, (value) => Boolean(value)),
+    ).toThrow(TypeError);
   });
 });

--- a/objectFunctions/hasKey.ts
+++ b/objectFunctions/hasKey.ts
@@ -14,7 +14,7 @@
  * @note Unlike the 'in' operator, this only checks own properties,
  * not those inherited from the prototype chain.
  */
-export function hasKey(obj: Record<string, any>, key: string): boolean {
+export function hasKey(obj: Record<string, unknown>, key: string): boolean {
   if (typeof obj !== 'object' || obj === null) {
     throw new TypeError('Input must be a non-null object');
   }

--- a/objectFunctions/isObjectEmpty.ts
+++ b/objectFunctions/isObjectEmpty.ts
@@ -17,7 +17,7 @@
  * @note This function only checks for own enumerable properties using Object.keys().
  * @note Non-enumerable properties and inherited properties are not considered.
  */
-export function isObjectEmpty(obj: Record<string, any>): boolean {
+export function isObjectEmpty(obj: Record<string, unknown>): boolean {
   if (typeof obj !== 'object' || obj === null) {
     throw new TypeError('Input must be a non-null object');
   }

--- a/objectFunctions/objectSize.ts
+++ b/objectFunctions/objectSize.ts
@@ -13,7 +13,7 @@
  * @note Only counts own enumerable properties (using Object.keys).
  * @note Non-enumerable properties and those on the prototype chain are not included.
  */
-export function objectSize(obj: Record<string, any>): number {
+export function objectSize(obj: Record<string, unknown>): number {
   if (typeof obj !== 'object' || obj === null) {
     throw new TypeError('Input must be a non-null object');
   }

--- a/objectFunctions/omitBy.ts
+++ b/objectFunctions/omitBy.ts
@@ -17,9 +17,9 @@
  * @note Creates a new object and doesn't modify the original.
  * @note Similar to Array.prototype.filter() but for object properties.
  */
-export function omitBy<T extends Record<string, any>>(
+export function omitBy<T extends Record<string, unknown>>(
   obj: T,
-  predicate: (value: any, key: string) => boolean,
+  predicate: (value: unknown, key: string) => boolean,
 ): Partial<T> {
   if (typeof obj !== 'object' || obj === null) {
     throw new TypeError('Input must be a non-null object');

--- a/objectFunctions/omitKeys.ts
+++ b/objectFunctions/omitKeys.ts
@@ -15,7 +15,7 @@
  * @note Creates a new object and doesn't modify the original.
  * @note If a key in keysToOmit doesn't exist in the object, it's simply ignored.
  */
-export function omitKeys<T extends Record<string, any>>(
+export function omitKeys<T extends Record<string, unknown>>(
   obj: T,
   keysToOmit: (keyof T)[],
 ): Partial<T> {

--- a/objectFunctions/pickBy.ts
+++ b/objectFunctions/pickBy.ts
@@ -16,9 +16,9 @@
  * @note Creates a new object and doesn't modify the original.
  * @note Similar to Array.prototype.filter() but for object properties.
  */
-export function pickBy<T extends Record<string, any>>(
+export function pickBy<T extends Record<string, unknown>>(
   obj: T,
-  predicate: (value: any, key: string) => boolean,
+  predicate: (value: unknown, key: string) => boolean,
 ): Partial<T> {
   if (typeof obj !== 'object' || obj === null) {
     throw new TypeError('Input must be a non-null object');


### PR DESCRIPTION
## Summary
- use `Record<string, unknown>` types in multiple object utilities
- adjust tests for stricter typings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e028bc6308325b07bf37f5e7a5ed8