### PR TITLE
Remove any casts

### DIFF
--- a/objectFunctions/deepFreeze.ts
+++ b/objectFunctions/deepFreeze.ts
@@ -22,7 +22,7 @@ export function deepFreeze<T>(obj: T): T {
   }
   Object.freeze(obj);
   Object.keys(obj).forEach((key) => {
-    const value = (obj as any)[key];
+    const value = (obj as Record<string, unknown>)[key];
     if (typeof value === 'object' && value !== null) {
       deepFreeze(value);
     }

--- a/objectFunctions/flipObject.ts
+++ b/objectFunctions/flipObject.ts
@@ -14,13 +14,13 @@
  * @note If the original object has duplicate values, the last key with that value will be used.
  * @note Complex values (objects, arrays) are converted to strings using toString().
  */
-export function flipObject<T extends Record<string, any>>(
+export function flipObject<T extends Record<string, unknown>>(
   obj: T,
 ): Record<string, string> {
   if (typeof obj !== 'object' || obj === null) {
     throw new TypeError('Input must be a non-null object');
   }
-  return Object.keys(obj).reduce((acc: Record<string, any>, key: string) => {
+  return Object.keys(obj).reduce((acc: Record<string, string>, key: string) => {
     acc[String(obj[key])] = key;
     return acc;
   }, {});

--- a/objectFunctions/groupBy.ts
+++ b/objectFunctions/groupBy.ts
@@ -34,7 +34,7 @@ export function groupBy<T>(array: T[], key: keyof T): Record<string, T[]> {
 
   return array.reduce<Record<string, T[]>>((acc, item) => {
     if (Object.prototype.hasOwnProperty.call(item, key)) {
-      const group = String((item as any)[key]);
+      const group = String(item[key]);
       if (!acc[group]) acc[group] = [];
       acc[group].push(item);
     }

--- a/objectFunctions/keyBy.ts
+++ b/objectFunctions/keyBy.ts
@@ -22,7 +22,7 @@
  * @note Property values are converted to strings when used as keys.
  * @note If multiple objects have the same key value, later objects will overwrite earlier ones.
  */
-export function keyBy<T extends Record<string, any>>(
+export function keyBy<T extends Record<string, unknown>>(
   array: T[],
   key: keyof T,
 ): Record<string, T> {


### PR DESCRIPTION
## Summary
- refactor groupBy to avoid any cast
- update deepFreeze to remove any cast
- tighten types for flipObject and keyBy

## Testing
- `npm test` *(fails: Allure is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687e10989b44832580144a8a39742e3b