### PR TITLE
Remove `any` from tests

### DIFF
--- a/functionsUnittests/objectFunctions/applyDefaults.test.ts
+++ b/functionsUnittests/objectFunctions/applyDefaults.test.ts
@@ -23,7 +23,7 @@ describe('applyDefaults', () => {
   it('3. should apply defaults to an empty object', () => {
     const obj = {};
     const defaults = { a: 1, b: 2 };
-    const result = applyDefaults(obj as any, defaults);
+    const result = applyDefaults(obj as unknown as Record<string, unknown>, defaults);
     const expected = { a: 1, b: 2 };
     expect(result).toEqual(expected);
   });
@@ -48,51 +48,51 @@ describe('applyDefaults', () => {
 
   // Test case 6: Handle non-object input for the first parameter (number)
   it('6. should throw a TypeError if the first input is a number', () => {
-    expect(() => applyDefaults(42 as any, { a: 1 })).toThrow(TypeError);
+    expect(() => applyDefaults(42 as unknown as Record<string, unknown>, { a: 1 })).toThrow(TypeError);
   });
 
   // Test case 7: Handle non-object input for the first parameter (string)
   it('7. should throw a TypeError if the first input is a string', () => {
-    expect(() => applyDefaults('string' as any, { a: 1 })).toThrow(TypeError);
+    expect(() => applyDefaults('string' as unknown as Record<string, unknown>, { a: 1 })).toThrow(TypeError);
   });
 
   // Test case 8: Handle non-object input for the first parameter (boolean)
   it('8. should throw a TypeError if the first input is a boolean', () => {
-    expect(() => applyDefaults(true as any, { a: 1 })).toThrow(TypeError);
+    expect(() => applyDefaults(true as unknown as Record<string, unknown>, { a: 1 })).toThrow(TypeError);
   });
 
   // Test case 9: Handle non-object input for the first parameter (null)
   it('9. should throw a TypeError if the first input is null', () => {
-    expect(() => applyDefaults(null as any, { a: 1 })).toThrow(TypeError);
+    expect(() => applyDefaults(null as unknown as Record<string, unknown>, { a: 1 })).toThrow(TypeError);
   });
 
   // Test case 10: Handle non-object input for the first parameter (undefined)
   it('10. should throw a TypeError if the first input is undefined', () => {
-    expect(() => applyDefaults(undefined as any, { a: 1 })).toThrow(TypeError);
+    expect(() => applyDefaults(undefined as unknown as Record<string, unknown>, { a: 1 })).toThrow(TypeError);
   });
 
   // Test case 11: Handle non-object input for the second parameter (number)
   it('11. should throw a TypeError if the second input is a number', () => {
-    expect(() => applyDefaults({ a: 1 }, 42 as any)).toThrow(TypeError);
+    expect(() => applyDefaults({ a: 1 }, 42 as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 12: Handle non-object input for the second parameter (string)
   it('12. should throw a TypeError if the second input is a string', () => {
-    expect(() => applyDefaults({ a: 1 }, 'string' as any)).toThrow(TypeError);
+    expect(() => applyDefaults({ a: 1 }, 'string' as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 13: Handle non-object input for the second parameter (boolean)
   it('13. should throw a TypeError if the second input is a boolean', () => {
-    expect(() => applyDefaults({ a: 1 }, true as any)).toThrow(TypeError);
+    expect(() => applyDefaults({ a: 1 }, true as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 14: Handle non-object input for the second parameter (null)
   it('14. should throw a TypeError if the second input is null', () => {
-    expect(() => applyDefaults({ a: 1 }, null as any)).toThrow(TypeError);
+    expect(() => applyDefaults({ a: 1 }, null as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 15: Handle non-object input for the second parameter (undefined)
   it('15. should throw a TypeError if the second input is undefined', () => {
-    expect(() => applyDefaults({ a: 1 }, undefined as any)).toThrow(TypeError);
+    expect(() => applyDefaults({ a: 1 }, undefined as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/countProperties.test.ts
+++ b/functionsUnittests/objectFunctions/countProperties.test.ts
@@ -27,26 +27,26 @@ describe('countProperties', () => {
 
   // Test case 4: Handle non-object input (number)
   it('4. should throw a TypeError if input is a number', () => {
-    expect(() => countProperties(42 as any)).toThrow(TypeError);
+    expect(() => countProperties(42 as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 5: Handle non-object input (string)
   it('5. should throw a TypeError if input is a string', () => {
-    expect(() => countProperties('string' as any)).toThrow(TypeError);
+    expect(() => countProperties('string' as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 6: Handle non-object input (boolean)
   it('6. should throw a TypeError if input is a boolean', () => {
-    expect(() => countProperties(true as any)).toThrow(TypeError);
+    expect(() => countProperties(true as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 7: Handle non-object input (null)
   it('7. should throw a TypeError if input is null', () => {
-    expect(() => countProperties(null as any)).toThrow(TypeError);
+    expect(() => countProperties(null as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 8: Handle non-object input (undefined)
   it('8. should throw a TypeError if input is undefined', () => {
-    expect(() => countProperties(undefined as any)).toThrow(TypeError);
+    expect(() => countProperties(undefined as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/deepCloneWith.test.ts
+++ b/functionsUnittests/objectFunctions/deepCloneWith.test.ts
@@ -1,7 +1,7 @@
 import { deepCloneWith } from '../../objectFunctions/deepCloneWith';
 
 describe('deepCloneWith', () => {
-  const cloneFn = (value: any) => value;
+  const cloneFn = (value: unknown) => value;
 
   // Test case 1: Deep clone a simple object
   it('1. should deep clone a simple object', () => {
@@ -80,26 +80,36 @@ describe('deepCloneWith', () => {
 
   // Test case 9: Handle non-object input (number)
   it('9. should throw a TypeError if input is a number', () => {
-    expect(() => deepCloneWith(42 as any, cloneFn)).toThrow(TypeError);
+    expect(() =>
+      deepCloneWith(42 as unknown as Record<string, unknown>, cloneFn)
+    ).toThrow(TypeError);
   });
 
   // Test case 10: Handle non-object input (string)
   it('10. should throw a TypeError if input is a string', () => {
-    expect(() => deepCloneWith('string' as any, cloneFn)).toThrow(TypeError);
+    expect(() =>
+      deepCloneWith('string' as unknown as Record<string, unknown>, cloneFn)
+    ).toThrow(TypeError);
   });
 
   // Test case 11: Handle non-object input (boolean)
   it('11. should throw a TypeError if input is a boolean', () => {
-    expect(() => deepCloneWith(true as any, cloneFn)).toThrow(TypeError);
+    expect(() =>
+      deepCloneWith(true as unknown as Record<string, unknown>, cloneFn)
+    ).toThrow(TypeError);
   });
 
   // Test case 12: Handle non-object input (null)
   it('12. should throw a TypeError if input is null', () => {
-    expect(() => deepCloneWith(null as any, cloneFn)).toThrow(TypeError);
+    expect(() =>
+      deepCloneWith(null as unknown as Record<string, unknown>, cloneFn)
+    ).toThrow(TypeError);
   });
 
   // Test case 13: Handle non-object input (undefined)
   it('13. should throw a TypeError if input is undefined', () => {
-    expect(() => deepCloneWith(undefined as any, cloneFn)).toThrow(TypeError);
+    expect(() =>
+      deepCloneWith(undefined as unknown as Record<string, unknown>, cloneFn)
+    ).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/deepEqual.test.ts
+++ b/functionsUnittests/objectFunctions/deepEqual.test.ts
@@ -77,26 +77,30 @@ describe('deepEqual', () => {
 
   // Test case 9: Handle non-object input (number)
   it('9. should return false if one input is a number', () => {
-    expect(deepEqual(42 as any, { a: 1 })).toBe(false);
+    expect(deepEqual(42 as unknown as Record<string, unknown>, { a: 1 })).toBe(false);
   });
 
   // Test case 10: Handle non-object input (string)
   it('10. should return false if one input is a string', () => {
-    expect(deepEqual('string' as any, { a: 1 })).toBe(false);
+    expect(
+      deepEqual('string' as unknown as Record<string, unknown>, { a: 1 })
+    ).toBe(false);
   });
 
   // Test case 11: Handle non-object input (boolean)
   it('11. should return false if one input is a boolean', () => {
-    expect(deepEqual(true as any, { a: 1 })).toBe(false);
+    expect(deepEqual(true as unknown as Record<string, unknown>, { a: 1 })).toBe(false);
   });
 
   // Test case 12: Handle non-object input (null)
   it('12. should return false if one input is null', () => {
-    expect(deepEqual(null as any, { a: 1 })).toBe(false);
+    expect(deepEqual(null as unknown as Record<string, unknown>, { a: 1 })).toBe(false);
   });
 
   // Test case 13: Handle non-object input (undefined)
   it('13. should return false if one input is undefined', () => {
-    expect(deepEqual(undefined as any, { a: 1 })).toBe(false);
+    expect(
+      deepEqual(undefined as unknown as Record<string, unknown>, { a: 1 })
+    ).toBe(false);
   });
 });

--- a/functionsUnittests/objectFunctions/deepFreeze.test.ts
+++ b/functionsUnittests/objectFunctions/deepFreeze.test.ts
@@ -55,26 +55,26 @@ describe('deepFreeze', () => {
 
   // Test case 5: Handle non-object input (number)
   it('5. should throw a TypeError if input is a number', () => {
-    expect(() => deepFreeze(42 as any)).toThrow(TypeError);
+    expect(() => deepFreeze(42 as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 6: Handle non-object input (string)
   it('6. should throw a TypeError if input is a string', () => {
-    expect(() => deepFreeze('string' as any)).toThrow(TypeError);
+    expect(() => deepFreeze('string' as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 7: Handle non-object input (boolean)
   it('7. should throw a TypeError if input is a boolean', () => {
-    expect(() => deepFreeze(true as any)).toThrow(TypeError);
+    expect(() => deepFreeze(true as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 8: Handle non-object input (null)
   it('8. should throw a TypeError if input is null', () => {
-    expect(() => deepFreeze(null as any)).toThrow(TypeError);
+    expect(() => deepFreeze(null as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 9: Handle non-object input (undefined)
   it('9. should throw a TypeError if input is undefined', () => {
-    expect(() => deepFreeze(undefined as any)).toThrow(TypeError);
+    expect(() => deepFreeze(undefined as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/deepMerge.test.ts
+++ b/functionsUnittests/objectFunctions/deepMerge.test.ts
@@ -74,51 +74,71 @@ describe('deepMerge', () => {
 
   // Test case 6: Handle non-object input for the target (number)
   it('6. should throw a TypeError if the target is a number', () => {
-    expect(() => deepMerge(42 as any, { a: 1 })).toThrow(TypeError);
+    expect(() =>
+      deepMerge(42 as unknown as Record<string, unknown>, { a: 1 })
+    ).toThrow(TypeError);
   });
 
   // Test case 7: Handle non-object input for the target (string)
   it('7. should throw a TypeError if the target is a string', () => {
-    expect(() => deepMerge('string' as any, { a: 1 })).toThrow(TypeError);
+    expect(() =>
+      deepMerge('string' as unknown as Record<string, unknown>, { a: 1 })
+    ).toThrow(TypeError);
   });
 
   // Test case 8: Handle non-object input for the target (boolean)
   it('8. should throw a TypeError if the target is a boolean', () => {
-    expect(() => deepMerge(true as any, { a: 1 })).toThrow(TypeError);
+    expect(() =>
+      deepMerge(true as unknown as Record<string, unknown>, { a: 1 })
+    ).toThrow(TypeError);
   });
 
   // Test case 9: Handle non-object input for the target (null)
   it('9. should throw a TypeError if the target is null', () => {
-    expect(() => deepMerge(null as any, { a: 1 })).toThrow(TypeError);
+    expect(() =>
+      deepMerge(null as unknown as Record<string, unknown>, { a: 1 })
+    ).toThrow(TypeError);
   });
 
   // Test case 10: Handle non-object input for the target (undefined)
   it('10. should throw a TypeError if the target is undefined', () => {
-    expect(() => deepMerge(undefined as any, { a: 1 })).toThrow(TypeError);
+    expect(() =>
+      deepMerge(undefined as unknown as Record<string, unknown>, { a: 1 })
+    ).toThrow(TypeError);
   });
 
   // Test case 11: Handle non-object input for the source (number)
   it('11. should throw a TypeError if the source is a number', () => {
-    expect(() => deepMerge({ a: 1 }, 42 as any)).toThrow(TypeError);
+    expect(() =>
+      deepMerge({ a: 1 }, 42 as unknown as Record<string, unknown>)
+    ).toThrow(TypeError);
   });
 
   // Test case 12: Handle non-object input for the source (string)
   it('12. should throw a TypeError if the source is a string', () => {
-    expect(() => deepMerge({ a: 1 }, 'string' as any)).toThrow(TypeError);
+    expect(() =>
+      deepMerge({ a: 1 }, 'string' as unknown as Record<string, unknown>)
+    ).toThrow(TypeError);
   });
 
   // Test case 13: Handle non-object input for the source (boolean)
   it('13. should throw a TypeError if the source is a boolean', () => {
-    expect(() => deepMerge({ a: 1 }, true as any)).toThrow(TypeError);
+    expect(() =>
+      deepMerge({ a: 1 }, true as unknown as Record<string, unknown>)
+    ).toThrow(TypeError);
   });
 
   // Test case 14: Handle non-object input for the source (null)
   it('14. should throw a TypeError if the source is null', () => {
-    expect(() => deepMerge({ a: 1 }, null as any)).toThrow(TypeError);
+    expect(() =>
+      deepMerge({ a: 1 }, null as unknown as Record<string, unknown>)
+    ).toThrow(TypeError);
   });
 
   // Test case 15: Handle non-object input for the source (undefined)
   it('15. should throw a TypeError if the source is undefined', () => {
-    expect(() => deepMerge({ a: 1 }, undefined as any)).toThrow(TypeError);
+    expect(() =>
+      deepMerge({ a: 1 }, undefined as unknown as Record<string, unknown>)
+    ).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/differenceBy.test.ts
+++ b/functionsUnittests/objectFunctions/differenceBy.test.ts
@@ -5,7 +5,7 @@ describe('differenceBy', () => {
   it('1. should return the key-value pairs from obj1 that differ from obj2', () => {
     const obj1 = { a: 1, b: 2, c: 3 };
     const obj2 = { a: 1, b: 4, c: 3 };
-    const comparator = (a: any, b: any) => a === b;
+    const comparator = (a: unknown, b: unknown) => a === b;
     const result = differenceBy(obj1, obj2, comparator);
     const expected = { b: 2 };
     expect(result).toEqual(expected);
@@ -15,7 +15,7 @@ describe('differenceBy', () => {
   it('2. should return an empty object if obj1 and obj2 are identical', () => {
     const obj1 = { a: 1, b: 2, c: 3 };
     const obj2 = { a: 1, b: 2, c: 3 };
-    const comparator = (a: any, b: any) => a === b;
+    const comparator = (a: unknown, b: unknown) => a === b;
     const result = differenceBy(obj1, obj2, comparator);
     const expected = {};
     expect(result).toEqual(expected);
@@ -25,7 +25,7 @@ describe('differenceBy', () => {
   it('3. should return an empty object if obj1 is empty', () => {
     const obj1 = {};
     const obj2 = { a: 1, b: 2, c: 3 };
-    const comparator = (a: any, b: any) => a === b;
+    const comparator = (a: unknown, b: unknown) => a === b;
     const result = differenceBy(obj1, obj2, comparator);
     const expected = {};
     expect(result).toEqual(expected);
@@ -35,7 +35,7 @@ describe('differenceBy', () => {
   it('4. should return all key-value pairs from obj1 if obj2 is empty', () => {
     const obj1 = { a: 1, b: 2, c: 3 };
     const obj2 = {};
-    const comparator = (a: any, b: any) => a === b;
+    const comparator = (a: unknown, b: unknown) => a === b;
     const result = differenceBy(obj1, obj2, comparator);
     const expected = { a: 1, b: 2, c: 3 };
     expect(result).toEqual(expected);
@@ -45,7 +45,8 @@ describe('differenceBy', () => {
   it('5. should use the custom comparator to determine differences', () => {
     const obj1 = { a: 'hello', b: 'world', c: 'test' };
     const obj2 = { a: 'HELLO', b: 'WORLD', c: 'test' };
-    const comparator = (a: any, b: any) => a.toLowerCase() === b.toLowerCase();
+    const comparator = (a: unknown, b: unknown) =>
+      String(a).toLowerCase() === String(b).toLowerCase();
     const result = differenceBy(obj1, obj2, comparator);
     const expected = {};
     expect(result).toEqual(expected);
@@ -55,7 +56,7 @@ describe('differenceBy', () => {
   it('6. should include keys from obj1 that are not present in obj2', () => {
     const obj1 = { a: 1, b: 2, c: 3 };
     const obj2 = { a: 1 };
-    const comparator = (a: any, b: any) => a === b;
+    const comparator = (a: unknown, b: unknown) => a === b;
     const result = differenceBy(obj1, obj2, comparator);
     const expected = { b: 2, c: 3 };
     expect(result).toEqual(expected);
@@ -65,7 +66,7 @@ describe('differenceBy', () => {
   it('7. should compare nested objects correctly', () => {
     const obj1 = { a: { x: 1 }, b: { y: 2 } };
     const obj2 = { a: { x: 1 }, b: { y: 3 } };
-    const comparator = (a: any, b: any) =>
+    const comparator = (a: unknown, b: unknown) =>
       JSON.stringify(a) === JSON.stringify(b);
     const result = differenceBy(obj1, obj2, comparator);
     const expected = { b: { y: 2 } };
@@ -76,7 +77,7 @@ describe('differenceBy', () => {
   it('8. should compare arrays as values correctly', () => {
     const obj1 = { a: [1, 2, 3], b: [4, 5, 6] };
     const obj2 = { a: [1, 2, 3], b: [4, 5, 7] };
-    const comparator = (a: any, b: any) =>
+    const comparator = (a: unknown, b: unknown) =>
       JSON.stringify(a) === JSON.stringify(b);
     const result = differenceBy(obj1, obj2, comparator);
     const expected = { b: [4, 5, 6] };
@@ -87,7 +88,7 @@ describe('differenceBy', () => {
   it('9. should handle objects with mixed data types', () => {
     const obj1 = { a: 1, b: 'string', c: true, d: null };
     const obj2 = { a: 1, b: 'different', c: false, d: null };
-    const comparator = (a: any, b: any) => a === b;
+    const comparator = (a: unknown, b: unknown) => a === b;
     const result = differenceBy(obj1, obj2, comparator);
     const expected = { b: 'string', c: true };
     expect(result).toEqual(expected);
@@ -95,9 +96,9 @@ describe('differenceBy', () => {
 
   // Test case 10: Handle undefined values in obj1 or obj2
   it('10. should handle undefined values in obj1 or obj2', () => {
-    const obj1 = { a: 1, b: undefined } as any;
+    const obj1 = { a: 1, b: undefined } as unknown as Record<string, unknown>;
     const obj2 = { a: 1, b: 2 };
-    const comparator = (a: any, b: any) => a === b;
+    const comparator = (a: unknown, b: unknown) => a === b;
     const result = differenceBy(obj1, obj2, comparator);
     const expected = { b: undefined };
     expect(result).toEqual(expected);
@@ -109,7 +110,7 @@ describe('differenceBy', () => {
     const sym2 = Symbol('key2');
     const obj1 = { [sym1]: 1, [sym2]: 2 };
     const obj2 = { [sym1]: 1, [sym2]: 3 };
-    const comparator = (a: any, b: any) => a === b;
+    const comparator = (a: unknown, b: unknown) => a === b;
     const result = differenceBy(obj1, obj2, comparator);
     const expected = { [sym2]: 2 };
     expect(result).toEqual(expected);
@@ -117,96 +118,174 @@ describe('differenceBy', () => {
 
   // Test case 12: Throw error if obj1 is not an object (number)
   it('12. should throw a TypeError if obj1 is a number', () => {
-    expect(() => differenceBy(42 as any, {}, (a, b) => a === b)).toThrow(
+    expect(() =>
+      differenceBy(
+        42 as unknown as Record<string, unknown>,
+        {},
+        (a, b) => a === b,
+      )
+    ).toThrow(
       TypeError,
     );
   });
 
   // Test case 13: Throw error if obj1 is not an object (string)
   it('13. should throw a TypeError if obj1 is a string', () => {
-    expect(() => differenceBy('string' as any, {}, (a, b) => a === b)).toThrow(
+    expect(() =>
+      differenceBy(
+        'string' as unknown as Record<string, unknown>,
+        {},
+        (a, b) => a === b,
+      )
+    ).toThrow(
       TypeError,
     );
   });
 
   // Test case 14: Throw error if obj1 is not an object (boolean)
   it('14. should throw a TypeError if obj1 is a boolean', () => {
-    expect(() => differenceBy(true as any, {}, (a, b) => a === b)).toThrow(
+    expect(() =>
+      differenceBy(
+        true as unknown as Record<string, unknown>,
+        {},
+        (a, b) => a === b,
+      )
+    ).toThrow(
       TypeError,
     );
   });
 
   // Test case 15: Throw error if obj1 is null
   it('15. should throw a TypeError if obj1 is null', () => {
-    expect(() => differenceBy(null as any, {}, (a, b) => a === b)).toThrow(
+    expect(() =>
+      differenceBy(
+        null as unknown as Record<string, unknown>,
+        {},
+        (a, b) => a === b,
+      )
+    ).toThrow(
       TypeError,
     );
   });
 
   // Test case 16: Throw error if obj1 is undefined
   it('16. should throw a TypeError if obj1 is undefined', () => {
-    expect(() => differenceBy(undefined as any, {}, (a, b) => a === b)).toThrow(
+    expect(() =>
+      differenceBy(
+        undefined as unknown as Record<string, unknown>,
+        {},
+        (a, b) => a === b,
+      )
+    ).toThrow(
       TypeError,
     );
   });
 
   // Test case 17: Throw error if obj2 is not an object (number)
   it('17. should throw a TypeError if obj2 is a number', () => {
-    expect(() => differenceBy({}, 42 as any, (a, b) => a === b)).toThrow(
+    expect(() =>
+      differenceBy(
+        {},
+        42 as unknown as Record<string, unknown>,
+        (a, b) => a === b,
+      )
+    ).toThrow(
       TypeError,
     );
   });
 
   // Test case 18: Throw error if obj2 is not an object (string)
   it('18. should throw a TypeError if obj2 is a string', () => {
-    expect(() => differenceBy({}, 'string' as any, (a, b) => a === b)).toThrow(
+    expect(() =>
+      differenceBy(
+        {},
+        'string' as unknown as Record<string, unknown>,
+        (a, b) => a === b,
+      )
+    ).toThrow(
       TypeError,
     );
   });
 
   // Test case 19: Throw error if obj2 is not an object (boolean)
   it('19. should throw a TypeError if obj2 is a boolean', () => {
-    expect(() => differenceBy({}, true as any, (a, b) => a === b)).toThrow(
+    expect(() =>
+      differenceBy(
+        {},
+        true as unknown as Record<string, unknown>,
+        (a, b) => a === b,
+      )
+    ).toThrow(
       TypeError,
     );
   });
 
   // Test case 20: Throw error if obj2 is null
   it('20. should throw a TypeError if obj2 is null', () => {
-    expect(() => differenceBy({}, null as any, (a, b) => a === b)).toThrow(
+    expect(() =>
+      differenceBy(
+        {},
+        null as unknown as Record<string, unknown>,
+        (a, b) => a === b,
+      )
+    ).toThrow(
       TypeError,
     );
   });
 
   // Test case 21: Throw error if obj2 is undefined
   it('21. should throw a TypeError if obj2 is undefined', () => {
-    expect(() => differenceBy({}, undefined as any, (a, b) => a === b)).toThrow(
+    expect(() =>
+      differenceBy(
+        {},
+        undefined as unknown as Record<string, unknown>,
+        (a, b) => a === b,
+      )
+    ).toThrow(
       TypeError,
     );
   });
 
   // Test case 22: Throw error if comparator is not a function (number)
   it('22. should throw a TypeError if comparator is a number', () => {
-    expect(() => differenceBy({}, {}, 42 as any)).toThrow(TypeError);
+    expect(() =>
+      differenceBy({}, {}, 42 as unknown as (a: unknown, b: unknown) => boolean)
+    ).toThrow(TypeError);
   });
 
   // Test case 23: Throw error if comparator is not a function (string)
   it('23. should throw a TypeError if comparator is a string', () => {
-    expect(() => differenceBy({}, {}, 'string' as any)).toThrow(TypeError);
+    expect(() =>
+      differenceBy(
+        {},
+        {},
+        'string' as unknown as (a: unknown, b: unknown) => boolean,
+      )
+    ).toThrow(TypeError);
   });
 
   // Test case 24: Throw error if comparator is not a function (boolean)
   it('24. should throw a TypeError if comparator is a boolean', () => {
-    expect(() => differenceBy({}, {}, true as any)).toThrow(TypeError);
+    expect(() =>
+      differenceBy({}, {}, true as unknown as (a: unknown, b: unknown) => boolean)
+    ).toThrow(TypeError);
   });
 
   // Test case 25: Throw error if comparator is null
   it('25. should throw a TypeError if comparator is null', () => {
-    expect(() => differenceBy({}, {}, null as any)).toThrow(TypeError);
+    expect(() =>
+      differenceBy({}, {}, null as unknown as (a: unknown, b: unknown) => boolean)
+    ).toThrow(TypeError);
   });
 
   // Test case 26: Throw error if comparator is undefined
   it('26. should throw a TypeError if comparator is undefined', () => {
-    expect(() => differenceBy({}, {}, undefined as any)).toThrow(TypeError);
+    expect(() =>
+      differenceBy(
+        {},
+        {},
+        undefined as unknown as (a: unknown, b: unknown) => boolean,
+      )
+    ).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/entriesToObject.test.ts
+++ b/functionsUnittests/objectFunctions/entriesToObject.test.ts
@@ -3,7 +3,7 @@ import { entriesToObject } from '../../objectFunctions/entriesToObject';
 describe('entriesToObject', () => {
   // Test case 1: Convert valid entries to an object
   it('Test case 1: should convert valid entries to an object', () => {
-    const entries: [string, any][] = [
+    const entries: [string, number][] = [
       ['a', 1],
       ['b', 2],
       ['c', 3],
@@ -15,7 +15,7 @@ describe('entriesToObject', () => {
 
   // Test case 2: Handle empty entries array
   it('Test case 2: should return an empty object for an empty entries array', () => {
-    const entries: [string, any][] = [];
+    const entries: [string, unknown][] = [];
     const result = entriesToObject(entries);
     const expected = {};
     expect(result).toEqual(expected);
@@ -23,7 +23,7 @@ describe('entriesToObject', () => {
 
   // Test case 8: Handle entries with duplicate keys
   it('Test case 3: should use the last value for duplicate keys', () => {
-    const entries: [string, any][] = [
+    const entries: [string, number][] = [
       ['a', 1],
       ['b', 2],
       ['a', 3],
@@ -35,7 +35,7 @@ describe('entriesToObject', () => {
 
   // Test case 9: Handle entries with various value types
   it('Test case 4: should handle entries with various value types', () => {
-    const entries: [string, any][] = [
+    const entries: [string, number | string | boolean | null | undefined][] = [
       ['a', 1],
       ['b', 'string'],
       ['c', true],
@@ -49,30 +49,30 @@ describe('entriesToObject', () => {
 
   // Test case 3: Handle entries with non-string keys
   it('Test case 5: should throw a TypeError if an entry has a non-string key', () => {
-    const entries: [string, any][] = [[123 as any, 'value']];
+    const entries: [string, unknown][] = [[123 as unknown as string, 'value']];
     expect(() => entriesToObject(entries)).toThrow(TypeError);
   });
 
   // Test case 4: Handle entries with invalid structure
   it('Test case 6: should throw a TypeError if an entry is not a [string, any] pair', () => {
-    const entries: any[] = [['a', 1], ['b'], 'invalid'];
-    expect(() => entriesToObject(entries as [string, any][])).toThrow(
+    const entries: unknown[] = [['a', 1], ['b'], 'invalid'];
+    expect(() => entriesToObject(entries as unknown as [string, unknown][])).toThrow(
       TypeError,
     );
   });
 
   // Test case 5: Handle non-array input
   it('Test case 7: should throw a TypeError if input is not an array', () => {
-    expect(() => entriesToObject(42 as any)).toThrow(TypeError);
+    expect(() => entriesToObject(42 as unknown as [string, unknown][])).toThrow(TypeError);
   });
 
   // Test case 6: Handle null input
   it('Test case 8: should throw a TypeError if input is null', () => {
-    expect(() => entriesToObject(null as any)).toThrow(TypeError);
+    expect(() => entriesToObject(null as unknown as [string, unknown][])).toThrow(TypeError);
   });
 
   // Test case 7: Handle undefined input
   it('Test case 9: should throw a TypeError if input is undefined', () => {
-    expect(() => entriesToObject(undefined as any)).toThrow(TypeError);
+    expect(() => entriesToObject(undefined as unknown as [string, unknown][])).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/flipObject.test.ts
+++ b/functionsUnittests/objectFunctions/flipObject.test.ts
@@ -59,26 +59,26 @@ describe('flipObject', () => {
 
   // Test case 6: Handle non-object input (number)
   it('6. should throw a TypeError if input is a number', () => {
-    expect(() => flipObject(42 as any)).toThrow(TypeError);
+    expect(() => flipObject(42 as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 7: Handle non-object input (string)
   it('7. should throw a TypeError if input is a string', () => {
-    expect(() => flipObject('string' as any)).toThrow(TypeError);
+    expect(() => flipObject('string' as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 8: Handle non-object input (boolean)
   it('8. should throw a TypeError if input is a boolean', () => {
-    expect(() => flipObject(true as any)).toThrow(TypeError);
+    expect(() => flipObject(true as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 9: Handle non-object input (null)
   it('9. should throw a TypeError if input is null', () => {
-    expect(() => flipObject(null as any)).toThrow(TypeError);
+    expect(() => flipObject(null as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 10: Handle non-object input (undefined)
   it('10. should throw a TypeError if input is undefined', () => {
-    expect(() => flipObject(undefined as any)).toThrow(TypeError);
+    expect(() => flipObject(undefined as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/fromDotNotation.test.ts
+++ b/functionsUnittests/objectFunctions/fromDotNotation.test.ts
@@ -105,26 +105,26 @@ describe('fromDotNotation', () => {
 
   // Test case 14: Throw error for non-object input (number)
   it('14. should throw a TypeError if input is a number', () => {
-    expect(() => fromDotNotation(42 as any)).toThrow(TypeError);
+    expect(() => fromDotNotation(42 as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 15: Throw error for non-object input (string)
   it('15. should throw a TypeError if input is a string', () => {
-    expect(() => fromDotNotation('string' as any)).toThrow(TypeError);
+    expect(() => fromDotNotation('string' as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 16: Throw error for non-object input (boolean)
   it('16. should throw a TypeError if input is a boolean', () => {
-    expect(() => fromDotNotation(true as any)).toThrow(TypeError);
+    expect(() => fromDotNotation(true as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 17: Throw error for null input
   it('17. should throw a TypeError if input is null', () => {
-    expect(() => fromDotNotation(null as any)).toThrow(TypeError);
+    expect(() => fromDotNotation(null as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 18: Throw error for undefined input
   it('18. should throw a TypeError if input is undefined', () => {
-    expect(() => fromDotNotation(undefined as any)).toThrow(TypeError);
+    expect(() => fromDotNotation(undefined as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/groupBy.test.ts
+++ b/functionsUnittests/objectFunctions/groupBy.test.ts
@@ -89,7 +89,7 @@ describe('groupBy', () => {
 
   // Test case 6: Handle empty array
   it('Test case 6: should return an empty object for an empty array', () => {
-    const array: any[] = [];
+    const array: Array<Record<string, unknown>> = [];
     const result = groupBy(array, 'category');
     const expected = {};
     expect(result).toEqual(expected);
@@ -125,26 +125,36 @@ describe('groupBy', () => {
 
   // Test case 9: Handle non-array input (number)
   it('Test case 9: should throw a TypeError if input is not an array', () => {
-    expect(() => groupBy(42 as any, 'category')).toThrow(TypeError);
+    expect(() =>
+      groupBy(42 as unknown as Array<Record<string, unknown>>, 'category')
+    ).toThrow(TypeError);
   });
 
   // Test case 10: Handle non-array input (string)
   it('Test case 10: should throw a TypeError if input is a string', () => {
-    expect(() => groupBy('string' as any, 'category')).toThrow(TypeError);
+    expect(() =>
+      groupBy('string' as unknown as Array<Record<string, unknown>>, 'category')
+    ).toThrow(TypeError);
   });
 
   // Test case 11: Handle non-array input (boolean)
   it('Test case 11: should throw a TypeError if input is a boolean', () => {
-    expect(() => groupBy(true as any, 'category')).toThrow(TypeError);
+    expect(() =>
+      groupBy(true as unknown as Array<Record<string, unknown>>, 'category')
+    ).toThrow(TypeError);
   });
 
   // Test case 12: Handle null input
   it('Test case 12: should throw a TypeError if input is null', () => {
-    expect(() => groupBy(null as any, 'category')).toThrow(TypeError);
+    expect(() =>
+      groupBy(null as unknown as Array<Record<string, unknown>>, 'category')
+    ).toThrow(TypeError);
   });
 
   // Test case 13: Handle undefined input
   it('Test case 13: should throw a TypeError if input is undefined', () => {
-    expect(() => groupBy(undefined as any, 'category')).toThrow(TypeError);
+    expect(() =>
+      groupBy(undefined as unknown as Array<Record<string, unknown>>, 'category')
+    ).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/hasKey.test.ts
+++ b/functionsUnittests/objectFunctions/hasKey.test.ts
@@ -81,26 +81,26 @@ describe('hasKey', () => {
 
   // Test case 9: Handle non-object input (number)
   it('9. should throw a TypeError if input is a number', () => {
-    expect(() => hasKey(42 as any, 'a')).toThrow(TypeError);
+    expect(() => hasKey(42 as unknown as Record<string, unknown>, 'a')).toThrow(TypeError);
   });
 
   // Test case 10: Handle non-object input (string)
   it('10. should throw a TypeError if input is a string', () => {
-    expect(() => hasKey('string' as any, 'a')).toThrow(TypeError);
+    expect(() => hasKey('string' as unknown as Record<string, unknown>, 'a')).toThrow(TypeError);
   });
 
   // Test case 11: Handle non-object input (boolean)
   it('11. should throw a TypeError if input is a boolean', () => {
-    expect(() => hasKey(true as any, 'a')).toThrow(TypeError);
+    expect(() => hasKey(true as unknown as Record<string, unknown>, 'a')).toThrow(TypeError);
   });
 
   // Test case 12: Handle non-object input (null)
   it('12. should throw a TypeError if input is null', () => {
-    expect(() => hasKey(null as any, 'a')).toThrow(TypeError);
+    expect(() => hasKey(null as unknown as Record<string, unknown>, 'a')).toThrow(TypeError);
   });
 
   // Test case 13: Handle non-object input (undefined)
   it('13. should throw a TypeError if input is undefined', () => {
-    expect(() => hasKey(undefined as any, 'a')).toThrow(TypeError);
+    expect(() => hasKey(undefined as unknown as Record<string, unknown>, 'a')).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/invertObject.test.ts
+++ b/functionsUnittests/objectFunctions/invertObject.test.ts
@@ -43,26 +43,36 @@ describe('invertObject', () => {
 
   // Test case 6: Handle non-object input (number)
   it('6. should throw a TypeError if input is a number', () => {
-    expect(() => invertObject(42 as any)).toThrow(TypeError);
+    expect(() => invertObject(42 as unknown as Record<string, unknown>)).toThrow(
+      TypeError,
+    );
   });
 
   // Test case 7: Handle non-object input (string)
   it('7. should throw a TypeError if input is a string', () => {
-    expect(() => invertObject('string' as any)).toThrow(TypeError);
+    expect(() =>
+      invertObject('string' as unknown as Record<string, unknown>)
+    ).toThrow(TypeError);
   });
 
   // Test case 8: Handle non-object input (boolean)
   it('8. should throw a TypeError if input is a boolean', () => {
-    expect(() => invertObject(true as any)).toThrow(TypeError);
+    expect(() => invertObject(true as unknown as Record<string, unknown>)).toThrow(
+      TypeError,
+    );
   });
 
   // Test case 9: Handle non-object input (null)
   it('9. should throw a TypeError if input is null', () => {
-    expect(() => invertObject(null as any)).toThrow(TypeError);
+    expect(() => invertObject(null as unknown as Record<string, unknown>)).toThrow(
+      TypeError,
+    );
   });
 
   // Test case 10: Handle non-object input (undefined)
   it('10. should throw a TypeError if input is undefined', () => {
-    expect(() => invertObject(undefined as any)).toThrow(TypeError);
+    expect(() =>
+      invertObject(undefined as unknown as Record<string, unknown>)
+    ).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/isObjectEmpty.test.ts
+++ b/functionsUnittests/objectFunctions/isObjectEmpty.test.ts
@@ -48,26 +48,36 @@ describe('isObjectEmpty', () => {
 
   // Test case 6: Handle non-object input (number)
   it('6. should throw a TypeError if input is a number', () => {
-    expect(() => isObjectEmpty(42 as any)).toThrow(TypeError);
+    expect(() => isObjectEmpty(42 as unknown as Record<string, unknown>)).toThrow(
+      TypeError,
+    );
   });
 
   // Test case 7: Handle non-object input (string)
   it('7. should throw a TypeError if input is a string', () => {
-    expect(() => isObjectEmpty('string' as any)).toThrow(TypeError);
+    expect(() =>
+      isObjectEmpty('string' as unknown as Record<string, unknown>)
+    ).toThrow(TypeError);
   });
 
   // Test case 8: Handle non-object input (boolean)
   it('8. should throw a TypeError if input is a boolean', () => {
-    expect(() => isObjectEmpty(true as any)).toThrow(TypeError);
+    expect(() => isObjectEmpty(true as unknown as Record<string, unknown>)).toThrow(
+      TypeError,
+    );
   });
 
   // Test case 9: Handle non-object input (null)
   it('9. should throw a TypeError if input is null', () => {
-    expect(() => isObjectEmpty(null as any)).toThrow(TypeError);
+    expect(() => isObjectEmpty(null as unknown as Record<string, unknown>)).toThrow(
+      TypeError,
+    );
   });
 
   // Test case 10: Handle non-object input (undefined)
   it('10. should throw a TypeError if input is undefined', () => {
-    expect(() => isObjectEmpty(undefined as any)).toThrow(TypeError);
+    expect(() =>
+      isObjectEmpty(undefined as unknown as Record<string, unknown>)
+    ).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/keyBy.test.ts
+++ b/functionsUnittests/objectFunctions/keyBy.test.ts
@@ -50,7 +50,7 @@ describe('keyBy', () => {
 
   // Test case 4: Handle empty array
   it('Test case 4: should return an empty object for an empty array', () => {
-    const array: any[] = [];
+    const array: Array<Record<string, unknown>> = [];
     const result = keyBy(array, 'id');
     const expected = {};
     expect(result).toEqual(expected);
@@ -70,26 +70,36 @@ describe('keyBy', () => {
 
   // Test case 6: Handle non-array input (number)
   it('Test case 6: should throw a TypeError if input is a number', () => {
-    expect(() => keyBy(42 as any, 'id')).toThrow(TypeError);
+    expect(() =>
+      keyBy(42 as unknown as Record<string, unknown>[], 'id')
+    ).toThrow(TypeError);
   });
 
   // Test case 7: Handle non-array input (string)
   it('Test case 7: should throw a TypeError if input is a string', () => {
-    expect(() => keyBy('string' as any, 'id')).toThrow(TypeError);
+    expect(() =>
+      keyBy('string' as unknown as Record<string, unknown>[], 'id')
+    ).toThrow(TypeError);
   });
 
   // Test case 8: Handle non-array input (boolean)
   it('Test case 8: should throw a TypeError if input is a boolean', () => {
-    expect(() => keyBy(true as any, 'id')).toThrow(TypeError);
+    expect(() =>
+      keyBy(true as unknown as Record<string, unknown>[], 'id')
+    ).toThrow(TypeError);
   });
 
   // Test case 9: Handle null input
   it('Test case 9: should throw a TypeError if input is null', () => {
-    expect(() => keyBy(null as any, 'id')).toThrow(TypeError);
+    expect(() =>
+      keyBy(null as unknown as Record<string, unknown>[], 'id')
+    ).toThrow(TypeError);
   });
 
   // Test case 10: Handle undefined input
   it('Test case 10: should throw a TypeError if input is undefined', () => {
-    expect(() => keyBy(undefined as any, 'id')).toThrow(TypeError);
+    expect(() =>
+      keyBy(undefined as unknown as Record<string, unknown>[], 'id')
+    ).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/objectToQueryString.test.ts
+++ b/functionsUnittests/objectFunctions/objectToQueryString.test.ts
@@ -58,26 +58,26 @@ describe('objectToQueryString', () => {
 
   // Test case 7: Handle non-object input (number)
   it('7. should throw a TypeError if input is a number', () => {
-    expect(() => objectToQueryString(42 as any)).toThrow(TypeError);
+    expect(() => objectToQueryString(42 as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 8: Handle non-object input (string)
   it('8. should throw a TypeError if input is a string', () => {
-    expect(() => objectToQueryString('string' as any)).toThrow(TypeError);
+    expect(() => objectToQueryString('string' as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 9: Handle non-object input (boolean)
   it('9. should throw a TypeError if input is a boolean', () => {
-    expect(() => objectToQueryString(true as any)).toThrow(TypeError);
+    expect(() => objectToQueryString(true as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 10: Handle non-object input (null)
   it('10. should throw a TypeError if input is null', () => {
-    expect(() => objectToQueryString(null as any)).toThrow(TypeError);
+    expect(() => objectToQueryString(null as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 11: Handle non-object input (undefined)
   it('11. should throw a TypeError if input is undefined', () => {
-    expect(() => objectToQueryString(undefined as any)).toThrow(TypeError);
+    expect(() => objectToQueryString(undefined as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/omitBy.test.ts
+++ b/functionsUnittests/objectFunctions/omitBy.test.ts
@@ -60,7 +60,9 @@ describe('omitBy', () => {
 
   // Test case 8: Handle non-object input (number)
   it('Test case 8: should throw a TypeError if input is a number', () => {
-    expect(() => omitBy(42 as any, (value) => Boolean(value))).toThrow(
+    expect(() =>
+      omitBy(42 as unknown as Record<string, unknown>, (value) => Boolean(value))
+    ).toThrow(
       TypeError,
     );
   });
@@ -68,20 +70,24 @@ describe('omitBy', () => {
   // Test case 9: Handle non-object input (string)
   it('Test case 9: should throw a TypeError if input is a string', () => {
     expect(() =>
-      omitBy('string' as any, (value) => Boolean(value)),
+      omitBy('string' as unknown as Record<string, unknown>, (value) => Boolean(value)),
     ).toThrow(TypeError);
   });
 
   // Test case 10: Handle non-object input (boolean)
   it('Test case 10: should throw a TypeError if input is a boolean', () => {
-    expect(() => omitBy(true as any, (value) => Boolean(value))).toThrow(
+    expect(() =>
+      omitBy(true as unknown as Record<string, unknown>, (value) => Boolean(value))
+    ).toThrow(
       TypeError,
     );
   });
 
   // Test case 11: Handle null input
   it('Test case 11: should throw a TypeError if input is null', () => {
-    expect(() => omitBy(null as any, (value) => Boolean(value))).toThrow(
+    expect(() =>
+      omitBy(null as unknown as Record<string, unknown>, (value) => Boolean(value))
+    ).toThrow(
       TypeError,
     );
   });
@@ -89,7 +95,7 @@ describe('omitBy', () => {
   // Test case 12: Handle undefined input
   it('Test case 12: should throw a TypeError if input is undefined', () => {
     expect(() =>
-      omitBy(undefined as any, (value) => Boolean(value)),
+      omitBy(undefined as unknown as Record<string, unknown>, (value) => Boolean(value)),
     ).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/omitKeys.test.ts
+++ b/functionsUnittests/objectFunctions/omitKeys.test.ts
@@ -12,7 +12,7 @@ describe('omitKeys', () => {
   // Test case 2: Omit keys that do not exist in the object
   it('2. should return the original object if keys to omit do not exist', () => {
     const obj = { a: 1, b: 2, c: 3 };
-    const result = omitKeys(obj, ['d', 'e'] as any);
+    const result = omitKeys(obj, ['d', 'e'] as unknown as Array<keyof typeof obj>);
     const expected = { a: 1, b: 2, c: 3 };
     expect(result).toEqual(expected);
   });
@@ -52,7 +52,7 @@ describe('omitKeys', () => {
   // Test case 6: Handle empty object
   it('6. should return an empty object if the input object is empty', () => {
     const obj = {};
-    const result = omitKeys(obj, ['a', 'b'] as any);
+    const result = omitKeys(obj, ['a', 'b'] as unknown as Array<keyof typeof obj>);
     const expected = {};
     expect(result).toEqual(expected);
   });
@@ -67,26 +67,36 @@ describe('omitKeys', () => {
 
   // Test case 8: Handle non-object input (number)
   it('8. should throw a TypeError if input is a number', () => {
-    expect(() => omitKeys(42 as any, ['a'])).toThrow(TypeError);
+    expect(() =>
+      omitKeys(42 as unknown as Record<string, unknown>, ['a'])
+    ).toThrow(TypeError);
   });
 
   // Test case 9: Handle non-object input (string)
   it('9. should throw a TypeError if input is a string', () => {
-    expect(() => omitKeys('string' as any, ['a'])).toThrow(TypeError);
+    expect(() =>
+      omitKeys('string' as unknown as Record<string, unknown>, ['a'])
+    ).toThrow(TypeError);
   });
 
   // Test case 10: Handle non-object input (boolean)
   it('10. should throw a TypeError if input is a boolean', () => {
-    expect(() => omitKeys(true as any, ['a'])).toThrow(TypeError);
+    expect(() =>
+      omitKeys(true as unknown as Record<string, unknown>, ['a'])
+    ).toThrow(TypeError);
   });
 
   // Test case 11: Handle non-object input (null)
   it('11. should throw a TypeError if input is null', () => {
-    expect(() => omitKeys(null as any, ['a'])).toThrow(TypeError);
+    expect(() =>
+      omitKeys(null as unknown as Record<string, unknown>, ['a'])
+    ).toThrow(TypeError);
   });
 
   // Test case 12: Handle non-object input (undefined)
   it('12. should throw a TypeError if input is undefined', () => {
-    expect(() => omitKeys(undefined as any, ['a'])).toThrow(TypeError);
+    expect(() =>
+      omitKeys(undefined as unknown as Record<string, unknown>, ['a'])
+    ).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/pickBy.test.ts
+++ b/functionsUnittests/objectFunctions/pickBy.test.ts
@@ -60,7 +60,9 @@ describe('pickBy', () => {
 
   // Test case 8: Handle non-object input (number)
   it('Test case 8: should throw a TypeError if input is a number', () => {
-    expect(() => pickBy(42 as any, (value) => Boolean(value))).toThrow(
+    expect(() =>
+      pickBy(42 as unknown as Record<string, unknown>, (value) => Boolean(value))
+    ).toThrow(
       TypeError,
     );
   });
@@ -68,20 +70,24 @@ describe('pickBy', () => {
   // Test case 9: Handle non-object input (string)
   it('Test case 9: should throw a TypeError if input is a string', () => {
     expect(() =>
-      pickBy('string' as any, (value) => Boolean(value)),
+      pickBy('string' as unknown as Record<string, unknown>, (value) => Boolean(value)),
     ).toThrow(TypeError);
   });
 
   // Test case 10: Handle non-object input (boolean)
   it('Test case 10: should throw a TypeError if input is a boolean', () => {
-    expect(() => pickBy(true as any, (value) => Boolean(value))).toThrow(
+    expect(() =>
+      pickBy(true as unknown as Record<string, unknown>, (value) => Boolean(value))
+    ).toThrow(
       TypeError,
     );
   });
 
   // Test case 11: Handle null input
   it('Test case 11: should throw a TypeError if input is null', () => {
-    expect(() => pickBy(null as any, (value) => Boolean(value))).toThrow(
+    expect(() =>
+      pickBy(null as unknown as Record<string, unknown>, (value) => Boolean(value))
+    ).toThrow(
       TypeError,
     );
   });
@@ -89,7 +95,7 @@ describe('pickBy', () => {
   // Test case 12: Handle undefined input
   it('Test case 12: should throw a TypeError if input is undefined', () => {
     expect(() =>
-      pickBy(undefined as any, (value) => Boolean(value)),
+      pickBy(undefined as unknown as Record<string, unknown>, (value) => Boolean(value)),
     ).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/pickKeys.test.ts
+++ b/functionsUnittests/objectFunctions/pickKeys.test.ts
@@ -12,7 +12,7 @@ describe('pickKeys', () => {
   // Test case 2: Pick keys that do not exist in the object
   it('2. should return an empty object if keys to pick do not exist', () => {
     const obj = { a: 1, b: 2, c: 3 };
-    const result = pickKeys(obj, ['d', 'e'] as any);
+    const result = pickKeys(obj, ['d', 'e'] as unknown as Array<keyof typeof obj>);
     const expected = {};
     expect(result).toEqual(expected);
   });
@@ -52,7 +52,7 @@ describe('pickKeys', () => {
   // Test case 6: Handle empty object
   it('6. should return an empty object if the input object is empty', () => {
     const obj = {};
-    const result = pickKeys(obj, ['a', 'b'] as any);
+    const result = pickKeys(obj, ['a', 'b'] as unknown as Array<keyof typeof obj>);
     const expected = {};
     expect(result).toEqual(expected);
   });
@@ -67,26 +67,26 @@ describe('pickKeys', () => {
 
   // Test case 8: Handle non-object input (number)
   it('8. should throw a TypeError if input is a number', () => {
-    expect(() => pickKeys(42 as any, ['a'])).toThrow(TypeError);
+    expect(() => pickKeys(42 as unknown as Record<string, unknown>, ['a'])).toThrow(TypeError);
   });
 
   // Test case 9: Handle non-object input (string)
   it('9. should throw a TypeError if input is a string', () => {
-    expect(() => pickKeys('string' as any, ['a'])).toThrow(TypeError);
+    expect(() => pickKeys('string' as unknown as Record<string, unknown>, ['a'])).toThrow(TypeError);
   });
 
   // Test case 10: Handle non-object input (boolean)
   it('10. should throw a TypeError if input is a boolean', () => {
-    expect(() => pickKeys(true as any, ['a'])).toThrow(TypeError);
+    expect(() => pickKeys(true as unknown as Record<string, unknown>, ['a'])).toThrow(TypeError);
   });
 
   // Test case 11: Handle non-object input (null)
   it('11. should throw a TypeError if input is null', () => {
-    expect(() => pickKeys(null as any, ['a'])).toThrow(TypeError);
+    expect(() => pickKeys(null as unknown as Record<string, unknown>, ['a'])).toThrow(TypeError);
   });
 
   // Test case 12: Handle non-object input (undefined)
   it('12. should throw a TypeError if input is undefined', () => {
-    expect(() => pickKeys(undefined as any, ['a'])).toThrow(TypeError);
+    expect(() => pickKeys(undefined as unknown as Record<string, unknown>, ['a'])).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/safeGet.test.ts
+++ b/functionsUnittests/objectFunctions/safeGet.test.ts
@@ -83,26 +83,26 @@ describe('safeGet', () => {
 
   // Test case 11: Handle non-object input (number)
   it('Test case 11: should throw a TypeError if input is a number', () => {
-    expect(() => safeGet(42 as any, 'a.b.c')).toThrow(TypeError);
+    expect(() => safeGet(42 as unknown as Record<string, unknown>, 'a.b.c')).toThrow(TypeError);
   });
 
   // Test case 12: Handle non-object input (string)
   it('Test case 12: should throw a TypeError if input is a string', () => {
-    expect(() => safeGet('string' as any, 'a.b.c')).toThrow(TypeError);
+    expect(() => safeGet('string' as unknown as Record<string, unknown>, 'a.b.c')).toThrow(TypeError);
   });
 
   // Test case 13: Handle non-object input (boolean)
   it('Test case 13: should throw a TypeError if input is a boolean', () => {
-    expect(() => safeGet(true as any, 'a.b.c')).toThrow(TypeError);
+    expect(() => safeGet(true as unknown as Record<string, unknown>, 'a.b.c')).toThrow(TypeError);
   });
 
   // Test case 14: Handle null input
   it('Test case 14: should throw a TypeError if input is null', () => {
-    expect(() => safeGet(null as any, 'a.b.c')).toThrow(TypeError);
+    expect(() => safeGet(null as unknown as Record<string, unknown>, 'a.b.c')).toThrow(TypeError);
   });
 
   // Test case 15: Handle undefined input
   it('Test case 15: should throw a TypeError if input is undefined', () => {
-    expect(() => safeGet(undefined as any, 'a.b.c')).toThrow(TypeError);
+    expect(() => safeGet(undefined as unknown as Record<string, unknown>, 'a.b.c')).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/sortObjectKeys.test.ts
+++ b/functionsUnittests/objectFunctions/sortObjectKeys.test.ts
@@ -59,26 +59,26 @@ describe('sortObjectKeys', () => {
 
   // Test case 8: Throw error for non-object input (number)
   it('8. should throw a TypeError if input is a number', () => {
-    expect(() => sortObjectKeys(42 as any)).toThrow(TypeError);
+    expect(() => sortObjectKeys(42 as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 9: Throw error for non-object input (string)
   it('9. should throw a TypeError if input is a string', () => {
-    expect(() => sortObjectKeys('string' as any)).toThrow(TypeError);
+    expect(() => sortObjectKeys('string' as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 10: Throw error for non-object input (boolean)
   it('10. should throw a TypeError if input is a boolean', () => {
-    expect(() => sortObjectKeys(true as any)).toThrow(TypeError);
+    expect(() => sortObjectKeys(true as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 11: Throw error for null input
   it('11. should throw a TypeError if input is null', () => {
-    expect(() => sortObjectKeys(null as any)).toThrow(TypeError);
+    expect(() => sortObjectKeys(null as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 12: Throw error for undefined input
   it('12. should throw a TypeError if input is undefined', () => {
-    expect(() => sortObjectKeys(undefined as any)).toThrow(TypeError);
+    expect(() => sortObjectKeys(undefined as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/unflattenObject.test.ts
+++ b/functionsUnittests/objectFunctions/unflattenObject.test.ts
@@ -61,26 +61,26 @@ describe('unflattenObject', () => {
 
   // Test case 6: Handle non-object input (number)
   it('6. should throw a TypeError if input is a number', () => {
-    expect(() => unflattenObject(42 as any)).toThrow(TypeError);
+    expect(() => unflattenObject(42 as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 7: Handle non-object input (string)
   it('7. should throw a TypeError if input is a string', () => {
-    expect(() => unflattenObject('string' as any)).toThrow(TypeError);
+    expect(() => unflattenObject('string' as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 8: Handle non-object input (boolean)
   it('8. should throw a TypeError if input is a boolean', () => {
-    expect(() => unflattenObject(true as any)).toThrow(TypeError);
+    expect(() => unflattenObject(true as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 9: Handle non-object input (null)
   it('9. should throw a TypeError if input is null', () => {
-    expect(() => unflattenObject(null as any)).toThrow(TypeError);
+    expect(() => unflattenObject(null as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 
   // Test case 10: Handle non-object input (undefined)
   it('10. should throw a TypeError if input is undefined', () => {
-    expect(() => unflattenObject(undefined as any)).toThrow(TypeError);
+    expect(() => unflattenObject(undefined as unknown as Record<string, unknown>)).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/uniqueValues.test.ts
+++ b/functionsUnittests/objectFunctions/uniqueValues.test.ts
@@ -13,7 +13,7 @@ describe('uniqueValues', () => {
   it('2. should return an empty array for an empty object', () => {
     const obj = {};
     const result = uniqueValues(obj);
-    const expected: any[] = [];
+    const expected: unknown[] = [];
     expect(result).toEqual(expected);
   });
 
@@ -96,26 +96,36 @@ describe('uniqueValues', () => {
 
   // Test case 12: Throw error if input is not an object (number)
   it('12. should throw a TypeError if input is a number', () => {
-    expect(() => uniqueValues(42 as any)).toThrow(TypeError);
+    expect(() => uniqueValues(42 as unknown as Record<string, unknown>)).toThrow(
+      TypeError,
+    );
   });
 
   // Test case 13: Throw error if input is not an object (string)
   it('13. should throw a TypeError if input is a string', () => {
-    expect(() => uniqueValues('string' as any)).toThrow(TypeError);
+    expect(() =>
+      uniqueValues('string' as unknown as Record<string, unknown>)
+    ).toThrow(TypeError);
   });
 
   // Test case 14: Throw error if input is not an object (boolean)
   it('14. should throw a TypeError if input is a boolean', () => {
-    expect(() => uniqueValues(true as any)).toThrow(TypeError);
+    expect(() => uniqueValues(true as unknown as Record<string, unknown>)).toThrow(
+      TypeError,
+    );
   });
 
   // Test case 15: Throw error if input is null
   it('15. should throw a TypeError if input is null', () => {
-    expect(() => uniqueValues(null as any)).toThrow(TypeError);
+    expect(() => uniqueValues(null as unknown as Record<string, unknown>)).toThrow(
+      TypeError,
+    );
   });
 
   // Test case 16: Throw error if input is undefined
   it('16. should throw a TypeError if input is undefined', () => {
-    expect(() => uniqueValues(undefined as any)).toThrow(TypeError);
+    expect(() =>
+      uniqueValues(undefined as unknown as Record<string, unknown>)
+    ).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/stringFunctions/extractSubstring.test.ts
+++ b/functionsUnittests/stringFunctions/extractSubstring.test.ts
@@ -137,9 +137,10 @@ describe('extractSubstring', () => {
   // Test case 14: Extract a substring with non-numeric start index
   it('14. should throw an error when start index is non-numeric', () => {
     const str: string = 'hello world';
-    const start: any = 'a';
     const length: number = 5;
-    expect(() => extractSubstring(str, start, length)).toThrow(
+    expect(() =>
+      extractSubstring(str, 'a' as unknown as number, length)
+    ).toThrow(
       'Start index and length must be numbers',
     );
   });
@@ -148,8 +149,9 @@ describe('extractSubstring', () => {
   it('15. should throw an error when length is non-numeric', () => {
     const str: string = 'hello world';
     const start: number = 0;
-    const length: any = 'a';
-    expect(() => extractSubstring(str, start, length)).toThrow(
+    expect(() =>
+      extractSubstring(str, start, 'a' as unknown as number)
+    ).toThrow(
       'Start index and length must be numbers',
     );
   });

--- a/functionsUnittests/stringFunctions/generateRandomAlphanumeric.test.ts
+++ b/functionsUnittests/stringFunctions/generateRandomAlphanumeric.test.ts
@@ -38,8 +38,9 @@ describe('generateRandomAlphanumeric', () => {
 
   // Test case 5: Generate a random alphanumeric string with non-numeric length
   it('5. should throw an error when length is non-numeric', () => {
-    const length: any = 'a';
-    expect(() => generateRandomAlphanumeric(length)).toThrow(
+    expect(() =>
+      generateRandomAlphanumeric('a' as unknown as number)
+    ).toThrow(
       'Length must be a non-negative number',
     );
   });

--- a/functionsUnittests/stringFunctions/generateRandomString.test.ts
+++ b/functionsUnittests/stringFunctions/generateRandomString.test.ts
@@ -46,10 +46,12 @@ describe('generateRandomString', () => {
 
   // Test case 5: Generate a random string with non-numeric length
   it('5. should throw an error when length is non-numeric', () => {
-    const length: any = 'a';
     const charset: string =
       'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    expect(() => generateRandomString(length, charset)).toThrow(
+    expect(() =>
+      // Cast to match the function signature intentionally with invalid input
+      generateRandomString('a' as unknown as number, charset)
+    ).toThrow(
       'Length must be a non-negative number',
     );
   });

--- a/functionsUnittests/stringFunctions/repeatString.test.ts
+++ b/functionsUnittests/stringFunctions/repeatString.test.ts
@@ -133,7 +133,6 @@ describe('repeatString', () => {
   // Error handling test case 2: Repeat a string with a non-numeric count
   it('15. should throw an error when repeating a string with a non-numeric count', () => {
     const str: string = 'hello';
-    const count: any = 'a';
-    expect(() => repeatString(str, count)).toThrow('Count must be a number');
+    expect(() => repeatString(str, 'a' as unknown as number)).toThrow('Count must be a number');
   });
 });

--- a/functionsUnittests/stringFunctions/repeatUntilLength.test.ts
+++ b/functionsUnittests/stringFunctions/repeatUntilLength.test.ts
@@ -133,8 +133,7 @@ describe('repeatUntilLength', () => {
   // Error handling test case 2: Repeat a string with a non-numeric length
   it('15. should throw an error when repeating a string with a non-numeric length', () => {
     const str: string = 'hello';
-    const length: any = 'a';
-    expect(() => repeatUntilLength(str, length)).toThrow(
+    expect(() => repeatUntilLength(str, 'a' as unknown as number)).toThrow(
       'Length must be a number',
     );
   });


### PR DESCRIPTION
## Summary
- replace `any` types in string and object function tests
- update differenceBy comparator types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f4fad14d083259648020277d764fd