### PR TITLE
Use structuredClone in deepClone

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ import { chunkArray, deepMerge } from 'ts-functions-library';
 The main folders group functions by purpose:
 
 - **arrayFunctions** – helpers for arrays such as `chunkArray`, `flattenArray`, and `mergeUnique`.
-- **objectFunctions** – utilities for manipulating objects including `deepMerge`, `safeGet`, and `groupByObject`.
+- **objectFunctions** – utilities for manipulating objects including `deepMerge`, `safeGet`, and `groupByObject`. The `deepClone` helper now uses Node's `structuredClone` when available and falls back to JSON serialization in older environments.
 - **stringFunctions** – text related helpers like `slugify`, `trimWhitespace`, and `isValidEmail`.
 - **dateFunctions** – date utilities such as `formatDate`, `addMonths`, and `getWeekNumber`.
 - **encodingFunctions** – simple Base64 encoding/decoding helpers.

--- a/functionsUnittests/objectFunctions/deepClone.test.ts
+++ b/functionsUnittests/objectFunctions/deepClone.test.ts
@@ -29,28 +29,48 @@ describe('deepClone', () => {
     expect(result[2]).not.toBe(arr[2]); // Ensure nested object is also cloned
   });
 
-  // Test case 4: Handle non-object input (number)
-  it('4. should throw a TypeError if input is a number', () => {
+  // Test case 4: Deep clone Date objects
+  it('4. should deep clone Date objects', () => {
+    const obj = { d: new Date('2020-01-01') };
+    const result = deepClone(obj);
+    expect(result).toEqual(obj);
+    expect(result).not.toBe(obj);
+    expect(result.d).not.toBe(obj.d);
+    expect(Object.prototype.toString.call(result.d)).toBe('[object Date]');
+  });
+
+  // Test case 5: Deep clone RegExp objects
+  it('5. should deep clone RegExp objects', () => {
+    const obj = { r: /test/gi };
+    const result = deepClone(obj);
+    expect(result).toEqual(obj);
+    expect(result).not.toBe(obj);
+    expect(result.r).not.toBe(obj.r);
+    expect(Object.prototype.toString.call(result.r)).toBe('[object RegExp]');
+  });
+
+  // Test case 6: Handle non-object input (number)
+  it('6. should throw a TypeError if input is a number', () => {
     expect(() => deepClone(42 as any)).toThrow(TypeError);
   });
 
-  // Test case 5: Handle non-object input (string)
-  it('5. should throw a TypeError if input is a string', () => {
+  // Test case 7: Handle non-object input (string)
+  it('7. should throw a TypeError if input is a string', () => {
     expect(() => deepClone('string' as any)).toThrow(TypeError);
   });
 
-  // Test case 6: Handle non-object input (boolean)
-  it('6. should throw a TypeError if input is a boolean', () => {
+  // Test case 8: Handle non-object input (boolean)
+  it('8. should throw a TypeError if input is a boolean', () => {
     expect(() => deepClone(true as any)).toThrow(TypeError);
   });
 
-  // Test case 7: Handle non-object input (null)
-  it('7. should throw a TypeError if input is null', () => {
+  // Test case 9: Handle non-object input (null)
+  it('9. should throw a TypeError if input is null', () => {
     expect(() => deepClone(null as any)).toThrow(TypeError);
   });
 
-  // Test case 8: Handle non-object input (undefined)
-  it('8. should throw a TypeError if input is undefined', () => {
+  // Test case 10: Handle non-object input (undefined)
+  it('10. should throw a TypeError if input is undefined', () => {
     expect(() => deepClone(undefined as any)).toThrow(TypeError);
   });
 });

--- a/objectFunctions/deepClone.ts
+++ b/objectFunctions/deepClone.ts
@@ -1,5 +1,6 @@
 /**
- * Creates a deep clone of an object or array using JSON serialization.
+ * Creates a deep clone of an object or array using `structuredClone` when
+ * available.
  *
  * @param obj - The object to clone.
  * @returns A deep copy of the input object.
@@ -10,12 +11,17 @@
  * const copy = deepClone(original);
  * copy.address.city = 'LA'; // Doesn't affect the original
  *
- * @note Has limitations: doesn't preserve functions, undefined values,
- * Date objects, RegExp, Maps, Sets, or circular references.
- */
+ * @note Falls back to JSON serialization if `structuredClone` is not
+ * available. The fallback has limitations: it doesn't preserve functions,
+ * undefined values, Date objects, RegExp, Maps, Sets, or circular
+ * references.
+*/
 export function deepClone<T>(obj: T): T {
   if (typeof obj !== 'object' || obj === null) {
     throw new TypeError('Input must be a non-null object');
+  }
+  if (typeof globalThis.structuredClone === 'function') {
+    return globalThis.structuredClone(obj);
   }
   return JSON.parse(JSON.stringify(obj));
 }


### PR DESCRIPTION
## Summary
- fall back to JSON serialization only if `structuredClone` is unavailable
- document new cloning behaviour in README
- update deepClone unit tests for Date and RegExp objects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fc77af5e48325ade15c06f647ef03