### PR TITLE
Refactor tests to avoid any[] types

### DIFF
--- a/functionsUnittests/arrayFunctionsUnittests/findIndexOfElement.test.ts
+++ b/functionsUnittests/arrayFunctionsUnittests/findIndexOfElement.test.ts
@@ -149,7 +149,7 @@ describe('findIndexOfElement', () => {
 
   // Test case 20: Array containing deeply nested arrays
   it('20. should handle arrays containing deeply nested arrays', () => {
-    const arr: any[] = [
+    const arr = [
       [1, [2, [3, [4]]]],
       [5, [6, [7, [8]]]],
     ];

--- a/functionsUnittests/arrayFunctionsUnittests/flattenArray.test.ts
+++ b/functionsUnittests/arrayFunctionsUnittests/flattenArray.test.ts
@@ -3,37 +3,37 @@ import { flattenArray } from '../../arrayFunctions/flattenArray';
 describe('flattenArray', () => {
   // Test case 1: Normal nested array of numbers
   it('1. should flatten a normal nested array of numbers', () => {
-    const arr: any[] = [1, [2, [3, 4], 5], 6];
+    const arr = [1, [2, [3, 4], 5], 6];
     expect(flattenArray<number>(arr)).toEqual([1, 2, 3, 4, 5, 6]);
   });
 
   // Test case 2: Deeply nested array of numbers
   it('2. should flatten a deeply nested array of numbers', () => {
-    const arr: any[] = [1, [2, [3, [4, [5]]]]];
+    const arr = [1, [2, [3, [4, [5]]]]];
     expect(flattenArray<number>(arr)).toEqual([1, 2, 3, 4, 5]);
   });
 
   // Test case 3: Array containing a mix of numbers and strings
   it('3. should flatten an array containing a mix of numbers and strings', () => {
-    const arr: any[] = [1, ['a', [2, 'b']], 3];
+    const arr = [1, ['a', [2, 'b']], 3];
     expect(flattenArray<number | string>(arr)).toEqual([1, 'a', 2, 'b', 3]);
   });
 
   // Test case 4: Array containing special characters
   it('4. should flatten an array containing special characters', () => {
-    const arr: any[] = ['@', ['#', ['$']], '%'];
+    const arr = ['@', ['#', ['$']], '%'];
     expect(flattenArray<string | number>(arr)).toEqual(['@', '#', '$', '%']);
   });
 
   // Test case 5: Array containing nested arrays of different lengths
   it('5. should flatten an array containing nested arrays of different lengths', () => {
-    const arr: any[] = [1, [2, [3, 4, [5, 6]]], 7];
+    const arr = [1, [2, [3, 4, [5, 6]]], 7];
     expect(flattenArray<number>(arr)).toEqual([1, 2, 3, 4, 5, 6, 7]);
   });
 
   // Test case 6: Array containing null and undefined
   it('6. should flatten an array containing null and undefined', () => {
-    const arr: any[] = [1, [null, [2, undefined]], 3];
+    const arr = [1, [null, [2, undefined]], 3];
     expect(flattenArray<number | null | undefined>(arr)).toEqual([
       1,
       null,
@@ -45,7 +45,7 @@ describe('flattenArray', () => {
 
   // Test case 7: Array containing NaN
   it('7. should flatten an array containing NaN', () => {
-    const arr: any[] = [1, [NaN, [2, NaN]], 3];
+    const arr = [1, [NaN, [2, NaN]], 3];
     expect(flattenArray<number | typeof NaN>(arr)).toEqual([1, NaN, 2, NaN, 3]);
   });
 
@@ -65,7 +65,7 @@ describe('flattenArray', () => {
   it('9. should flatten an array containing functions', () => {
     const func1: () => number = () => 1;
     const func2: () => number = () => 2;
-    const arr: any[] = [1, [func1, [2, func2]], 3];
+    const arr = [1, [func1, [2, func2]], 3];
     expect(flattenArray<number | (() => number)>(arr)).toEqual([
       1,
       func1,
@@ -79,7 +79,7 @@ describe('flattenArray', () => {
   it('10. should flatten an array containing symbols', () => {
     const sym1: symbol = Symbol('symbol1');
     const sym2: symbol = Symbol('symbol2');
-    const arr: any[] = [1, [sym1, [2, sym2]], 3];
+    const arr = [1, [sym1, [2, sym2]], 3];
     expect(flattenArray<number | symbol>(arr)).toEqual([1, sym1, 2, sym2, 3]);
   });
 
@@ -87,7 +87,7 @@ describe('flattenArray', () => {
   it('11. should flatten an array containing dates', () => {
     const date1: Date = new Date(2020, 0, 1);
     const date2: Date = new Date(2021, 0, 1);
-    const arr: any[] = [1, [date1, [2, date2]], 3];
+    const arr = [1, [date1, [2, date2]], 3];
     expect(flattenArray<number | Date>(arr)).toEqual([1, date1, 2, date2, 3]);
   });
 
@@ -95,7 +95,7 @@ describe('flattenArray', () => {
   it('12. should flatten an array containing regex', () => {
     const regex1: RegExp = /abc/;
     const regex2: RegExp = /def/;
-    const arr: any[] = [1, [regex1, [2, regex2]], 3];
+    const arr = [1, [regex1, [2, regex2]], 3];
     expect(flattenArray<number | RegExp>(arr)).toEqual([
       1,
       regex1,

--- a/functionsUnittests/arrayFunctionsUnittests/flattenArrayDepth.test.ts
+++ b/functionsUnittests/arrayFunctionsUnittests/flattenArrayDepth.test.ts
@@ -3,19 +3,19 @@ import { flattenArrayDepth } from '../../arrayFunctions/flattenArrayDepth';
 describe('flattenArrayDepth', () => {
   // Test case 1: Normal nested array of numbers
   it('1. should flatten a normal nested array of numbers to the specified depth', () => {
-    const arr: any[] = [1, [2, [3, 4], 5], 6];
+    const arr = [1, [2, [3, 4], 5], 6];
     expect(flattenArrayDepth<number>(arr, 2)).toEqual([1, 2, 3, 4, 5, 6]);
   });
 
   // Test case 2: Deeply nested array of numbers
   it('2. should flatten a deeply nested array of numbers to the specified depth', () => {
-    const arr: any[] = [1, [2, [3, [4, [5]]]]];
+    const arr = [1, [2, [3, [4, [5]]]]];
     expect(flattenArrayDepth<number>(arr, 3)).toEqual([1, 2, 3, 4, [5]]);
   });
 
   // Test case 3: Array containing a mix of numbers and strings
   it('3. should flatten an array containing a mix of numbers and strings to the specified depth', () => {
-    const arr: any[] = [1, ['a', [2, 'b']], 3];
+    const arr = [1, ['a', [2, 'b']], 3];
     expect(flattenArrayDepth<number | string>(arr, 2)).toEqual([
       1,
       'a',
@@ -27,7 +27,7 @@ describe('flattenArrayDepth', () => {
 
   // Test case 4: Array containing special characters
   it('4. should flatten an array containing special characters to the specified depth', () => {
-    const arr: any[] = ['@', ['#', ['$']], '%'];
+    const arr = ['@', ['#', ['$']], '%'];
     expect(flattenArrayDepth<string | number>(arr, 2)).toEqual([
       '@',
       '#',
@@ -38,13 +38,13 @@ describe('flattenArrayDepth', () => {
 
   // Test case 5: Array containing nested arrays of different lengths
   it('5. should flatten an array containing nested arrays of different lengths to the specified depth', () => {
-    const arr: any[] = [1, [2, [3, 4, [5, 6]]], 7];
+    const arr = [1, [2, [3, 4, [5, 6]]], 7];
     expect(flattenArrayDepth<number>(arr, 2)).toEqual([1, 2, 3, 4, [5, 6], 7]);
   });
 
   // Test case 6: Array containing null and undefined
   it('6. should flatten an array containing null and undefined to the specified depth', () => {
-    const arr: any[] = [1, [null, [2, undefined]], 3];
+    const arr = [1, [null, [2, undefined]], 3];
     expect(flattenArrayDepth<number | null | undefined>(arr, 2)).toEqual([
       1,
       null,
@@ -56,7 +56,7 @@ describe('flattenArrayDepth', () => {
 
   // Test case 7: Array containing NaN
   it('7. should flatten an array containing NaN to the specified depth', () => {
-    const arr: any[] = [1, [NaN, [2, NaN]], 3];
+    const arr = [1, [NaN, [2, NaN]], 3];
     expect(flattenArrayDepth<number | typeof NaN>(arr, 2)).toEqual([
       1,
       NaN,
@@ -88,7 +88,7 @@ describe('flattenArrayDepth', () => {
   it('9. should flatten an array containing functions to the specified depth', () => {
     const func1: () => number = () => 1;
     const func2: () => number = () => 2;
-    const arr: any[] = [1, [func1, [2, func2]], 3];
+    const arr = [1, [func1, [2, func2]], 3];
     expect(flattenArrayDepth<number | (() => number)>(arr, 2)).toEqual([
       1,
       func1,
@@ -102,7 +102,7 @@ describe('flattenArrayDepth', () => {
   it('10. should flatten an array containing symbols to the specified depth', () => {
     const sym1: symbol = Symbol('symbol1');
     const sym2: symbol = Symbol('symbol2');
-    const arr: any[] = [1, [sym1, [2, sym2]], 3];
+    const arr = [1, [sym1, [2, sym2]], 3];
     expect(flattenArrayDepth<number | symbol>(arr, 2)).toEqual([
       1,
       sym1,
@@ -116,7 +116,7 @@ describe('flattenArrayDepth', () => {
   it('11. should flatten an array containing dates to the specified depth', () => {
     const date1: Date = new Date(2020, 0, 1);
     const date2: Date = new Date(2021, 0, 1);
-    const arr: any[] = [1, [date1, [2, date2]], 3];
+    const arr = [1, [date1, [2, date2]], 3];
     expect(flattenArrayDepth<number | Date>(arr, 2)).toEqual([
       1,
       date1,
@@ -130,7 +130,7 @@ describe('flattenArrayDepth', () => {
   it('12. should flatten an array containing regex to the specified depth', () => {
     const regex1: RegExp = /abc/;
     const regex2: RegExp = /def/;
-    const arr: any[] = [1, [regex1, [2, regex2]], 3];
+    const arr = [1, [regex1, [2, regex2]], 3];
     expect(flattenArrayDepth<number | RegExp>(arr, 2)).toEqual([
       1,
       regex1,
@@ -161,19 +161,19 @@ describe('flattenArrayDepth', () => {
 
   // Test case 15: Depth 0
   it('15. should return the original array when depth is 0', () => {
-    const arr: any[] = [1, [2, [3, 4], 5], 6];
+    const arr = [1, [2, [3, 4], 5], 6];
     expect(flattenArrayDepth<number>(arr, 0)).toEqual(arr);
   });
 
   // Test case 16: Depth 1
   it('16. should flatten the array by one level when depth is 1', () => {
-    const arr: any[] = [1, [2, [3, 4], 5], 6];
+    const arr = [1, [2, [3, 4], 5], 6];
     expect(flattenArrayDepth<number>(arr, 1)).toEqual([1, 2, [3, 4], 5, 6]);
   });
 
   // Test case 17: Depth greater than the nesting level
   it('17. should flatten the array completely when depth is greater than the nesting level', () => {
-    const arr: any[] = [1, [2, [3, 4], 5], 6];
+    const arr = [1, [2, [3, 4], 5], 6];
     expect(flattenArrayDepth<number>(arr, 10)).toEqual([1, 2, 3, 4, 5, 6]);
   });
 });

--- a/functionsUnittests/arrayFunctionsUnittests/removeFalsyValues.test.ts
+++ b/functionsUnittests/arrayFunctionsUnittests/removeFalsyValues.test.ts
@@ -51,8 +51,8 @@ describe('removeFalsyValues', () => {
 
   // Test case 4: Removing falsy values from an empty array
   test('4. should return an empty array when the input array is empty', () => {
-    const array: any[] = [];
-    const result: any[] = removeFalsyValues(array);
+    const array: [] = [];
+    const result = removeFalsyValues(array);
     expect(result).toEqual([]);
   });
 

--- a/functionsUnittests/arrayFunctionsUnittests/rotateArrayLeft.test.ts
+++ b/functionsUnittests/arrayFunctionsUnittests/rotateArrayLeft.test.ts
@@ -27,9 +27,9 @@ describe('rotateArrayLeft', () => {
 
   // Test case 4: Rotating an empty array
   test('4. should return an empty array when the input array is empty', () => {
-    const array: any[] = [];
+    const array: [] = [];
     const positions: number = 3;
-    const result: any[] = rotateArrayLeft(array, positions);
+    const result = rotateArrayLeft(array, positions);
     expect(result).toEqual([]);
   });
 

--- a/functionsUnittests/arrayFunctionsUnittests/rotateArrayRight.test.ts
+++ b/functionsUnittests/arrayFunctionsUnittests/rotateArrayRight.test.ts
@@ -27,9 +27,9 @@ describe('rotateArrayRight', () => {
 
   // Test case 4: Rotating an empty array
   test('4. should return an empty array when the input array is empty', () => {
-    const array: any[] = [];
+    const array: [] = [];
     const positions: number = 3;
-    const result: any[] = rotateArrayRight(array, positions);
+    const result = rotateArrayRight(array, positions);
     expect(result).toEqual([]);
   });
 

--- a/functionsUnittests/arrayFunctionsUnittests/sortBy.test.ts
+++ b/functionsUnittests/arrayFunctionsUnittests/sortBy.test.ts
@@ -81,8 +81,8 @@ describe('sortBy', () => {
 
   // Test case 6: Sorting an empty array
   test('6. should return an empty array when the input array is empty', () => {
-    const array: any[] = [];
-    const result: any[] = sortBy(array, 'id');
+    const array: [] = [];
+    const result = sortBy(array, 'id');
     expect(result).toEqual([]);
   });
 

--- a/functionsUnittests/arrayFunctionsUnittests/uniqueElementsWithCounts.test.ts
+++ b/functionsUnittests/arrayFunctionsUnittests/uniqueElementsWithCounts.test.ts
@@ -47,8 +47,8 @@ describe('uniqueElementsWithCounts', () => {
 
   // Test case 4: Unique elements with counts in an empty array
   test('4. should return an empty array when the input array is empty', () => {
-    const array: any[] = [];
-    const result: any[] = uniqueElementsWithCounts(array);
+    const array: [] = [];
+    const result = uniqueElementsWithCounts(array);
     expect(result).toEqual([]);
   });
 

--- a/functionsUnittests/arrayFunctionsUnittests/zipMultiple.test.ts
+++ b/functionsUnittests/arrayFunctionsUnittests/zipMultiple.test.ts
@@ -6,7 +6,7 @@ describe('zipMultiple', () => {
     const names: string[] = ['Alice', 'Bob', 'Charlie'];
     const ages: number[] = [25, 30, 35];
     const cities: string[] = ['New York', 'Los Angeles', 'Chicago'];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [string, number, string][] = zipMultiple(names, ages, cities);
     expect(result).toEqual([
       ['Alice', 25, 'New York'],
       ['Bob', 30, 'Los Angeles'],
@@ -19,7 +19,7 @@ describe('zipMultiple', () => {
     const names: string[] = ['Alice', 'Bob'];
     const ages: number[] = [25, 30, 35];
     const cities: string[] = ['New York', 'Los Angeles'];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [string, number, string][] = zipMultiple(names, ages, cities);
     expect(result).toEqual([
       ['Alice', 25, 'New York'],
       ['Bob', 30, 'Los Angeles'],
@@ -31,7 +31,7 @@ describe('zipMultiple', () => {
     const names: string[] = ['Alice', 'Bob'];
     const ages: number[] = [];
     const cities: string[] = ['New York', 'Los Angeles'];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [string, number, string][] = zipMultiple(names, ages, cities);
     expect(result).toEqual([]);
   });
 
@@ -40,7 +40,7 @@ describe('zipMultiple', () => {
     const names: string[] = [];
     const ages: number[] = [];
     const cities: string[] = [];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [string, number, string][] = zipMultiple(names, ages, cities);
     expect(result).toEqual([]);
   });
 
@@ -49,7 +49,11 @@ describe('zipMultiple', () => {
     const names: string[] = ['Alice', 'Bob'];
     const ages: (number | string)[] = [25, 'thirty'];
     const cities: (string | boolean)[] = ['New York', true];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [string, number | string, string | boolean][] = zipMultiple(
+      names,
+      ages,
+      cities,
+    );
     expect(result).toEqual([
       ['Alice', 25, 'New York'],
       ['Bob', 'thirty', true],
@@ -61,7 +65,11 @@ describe('zipMultiple', () => {
     const names: string[][] = [['Alice'], ['Bob']];
     const ages: number[][] = [[25], [30]];
     const cities: string[][] = [['New York'], ['Los Angeles']];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [string[], number[], string[]][] = zipMultiple(
+      names,
+      ages,
+      cities,
+    );
     expect(result).toEqual([
       [['Alice'], [25], ['New York']],
       [['Bob'], [30], ['Los Angeles']],
@@ -73,7 +81,7 @@ describe('zipMultiple', () => {
     const names: string[] = ['Alice', 'Bob'];
     const ages: boolean[] = [true, false];
     const cities: string[] = ['New York', 'Los Angeles'];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [string, boolean, string][] = zipMultiple(names, ages, cities);
     expect(result).toEqual([
       ['Alice', true, 'New York'],
       ['Bob', false, 'Los Angeles'],
@@ -87,7 +95,7 @@ describe('zipMultiple', () => {
     const names: string[] = ['Alice', 'Bob'];
     const ages: symbol[] = [sym1, sym2];
     const cities: string[] = ['New York', 'Los Angeles'];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [string, symbol, string][] = zipMultiple(names, ages, cities);
     expect(result).toEqual([
       ['Alice', sym1, 'New York'],
       ['Bob', sym2, 'Los Angeles'],
@@ -101,7 +109,11 @@ describe('zipMultiple', () => {
     const names: string[] = ['Alice', 'Bob'];
     const ages: (() => void)[] = [func1, func2];
     const cities: string[] = ['New York', 'Los Angeles'];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [string, () => void, string][] = zipMultiple(
+      names,
+      ages,
+      cities,
+    );
     expect(result).toEqual([
       ['Alice', func1, 'New York'],
       ['Bob', func2, 'Los Angeles'],
@@ -115,7 +127,7 @@ describe('zipMultiple', () => {
     const names: string[] = ['Alice', 'Bob'];
     const ages: Date[] = [date1, date2];
     const cities: string[] = ['New York', 'Los Angeles'];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [string, Date, string][] = zipMultiple(names, ages, cities);
     expect(result).toEqual([
       ['Alice', date1, 'New York'],
       ['Bob', date2, 'Los Angeles'],
@@ -129,7 +141,7 @@ describe('zipMultiple', () => {
     const names: string[] = ['Alice', 'Bob'];
     const ages: RegExp[] = [regex1, regex2];
     const cities: string[] = ['New York', 'Los Angeles'];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [string, RegExp, string][] = zipMultiple(names, ages, cities);
     expect(result).toEqual([
       ['Alice', regex1, 'New York'],
       ['Bob', regex2, 'Los Angeles'],
@@ -141,7 +153,7 @@ describe('zipMultiple', () => {
     const names: string[] = ['Alice', 'Bob'];
     const ages: bigint[] = [BigInt(25), BigInt(30)];
     const cities: string[] = ['New York', 'Los Angeles'];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [string, bigint, string][] = zipMultiple(names, ages, cities);
     expect(result).toEqual([
       ['Alice', BigInt(25), 'New York'],
       ['Bob', BigInt(30), 'Los Angeles'],
@@ -153,7 +165,7 @@ describe('zipMultiple', () => {
     const names: string[] = ['Alice', 'Bob'];
     const ages: number[] = [Infinity, -Infinity];
     const cities: string[] = ['New York', 'Los Angeles'];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [string, number, string][] = zipMultiple(names, ages, cities);
     expect(result).toEqual([
       ['Alice', Infinity, 'New York'],
       ['Bob', -Infinity, 'Los Angeles'],
@@ -165,7 +177,7 @@ describe('zipMultiple', () => {
     const names: string[] = ['Alice', 'Bob'];
     const ages: number[] = [NaN, 30];
     const cities: string[] = ['New York', 'Los Angeles'];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [string, number, string][] = zipMultiple(names, ages, cities);
     expect(result).toEqual([
       ['Alice', NaN, 'New York'],
       ['Bob', 30, 'Los Angeles'],
@@ -177,7 +189,8 @@ describe('zipMultiple', () => {
     const names: (string | number)[] = ['Alice', 42];
     const ages: (number | string)[] = [25, 'thirty'];
     const cities: (string | boolean)[] = ['New York', true];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [string | number, number | string, string | boolean][] =
+      zipMultiple(names, ages, cities);
     expect(result).toEqual([
       ['Alice', 25, 'New York'],
       [42, 'thirty', true],
@@ -191,7 +204,11 @@ describe('zipMultiple', () => {
     const names: (symbol | (() => void))[] = [sym1, func1];
     const ages: (symbol | (() => void))[] = [sym1, func1];
     const cities: (symbol | (() => void))[] = [sym1, func1];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [
+      symbol | (() => void),
+      symbol | (() => void),
+      symbol | (() => void)
+    ][] = zipMultiple(names, ages, cities);
     expect(result).toEqual([
       [sym1, sym1, sym1],
       [func1, func1, func1],
@@ -205,7 +222,11 @@ describe('zipMultiple', () => {
     const names: (Date | RegExp)[] = [date1, regex1];
     const ages: (Date | RegExp)[] = [date1, regex1];
     const cities: (Date | RegExp)[] = [date1, regex1];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [
+      Date | RegExp,
+      Date | RegExp,
+      Date | RegExp
+    ][] = zipMultiple(names, ages, cities);
     expect(result).toEqual([
       [date1, date1, date1],
       [regex1, regex1, regex1],
@@ -217,7 +238,11 @@ describe('zipMultiple', () => {
     const names: (string | null)[] = ['Alice', null];
     const ages: (number | null)[] = [25, null];
     const cities: (string | null)[] = ['New York', null];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [string | null, number | null, string | null][] = zipMultiple(
+      names,
+      ages,
+      cities,
+    );
     expect(result).toEqual([
       ['Alice', 25, 'New York'],
       [null, null, null],
@@ -229,7 +254,11 @@ describe('zipMultiple', () => {
     const names: (string | undefined)[] = ['Alice', undefined];
     const ages: (number | undefined)[] = [25, undefined];
     const cities: (string | undefined)[] = ['New York', undefined];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [
+      string | undefined,
+      number | undefined,
+      string | undefined
+    ][] = zipMultiple(names, ages, cities);
     expect(result).toEqual([
       ['Alice', 25, 'New York'],
       [undefined, undefined, undefined],
@@ -241,7 +270,11 @@ describe('zipMultiple', () => {
     const names: (string | null | undefined)[] = ['Alice', null, undefined];
     const ages: (number | null | undefined)[] = [25, null, undefined];
     const cities: (string | null | undefined)[] = ['New York', null, undefined];
-    const result: any[][] = zipMultiple(names, ages, cities);
+    const result: [
+      string | null | undefined,
+      number | null | undefined,
+      string | null | undefined
+    ][] = zipMultiple(names, ages, cities);
     expect(result).toEqual([
       ['Alice', 25, 'New York'],
       [null, null, null],


### PR DESCRIPTION
## Summary
- refine array unit tests by removing `any[]` typings
- specialize `zipMultiple.test.ts` with typed tuple results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688136c1514483259684f04caf1e8b7f