### PR TITLE
Use dedicated tsconfig for tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -28,6 +28,11 @@ const Status = {
 
 const config = {
   preset: 'ts-jest',
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.test.json',
+    },
+  },
   testEnvironment: 'allure-jest/node',
   testEnvironmentOptions: {
     resultsDir: 'allure-results',

--- a/jest.local.config.ts
+++ b/jest.local.config.ts
@@ -1,5 +1,10 @@
 module.exports = {
   preset: 'ts-jest',
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.test.json',
+    },
+  },
   testEnvironment: 'node', // Change to standard node environment
   reporters: [
     'default', // default jest reporter

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,10 +20,7 @@
     "mathFunctions",
     "objectFunctions",
     "stringFunctions",
-    "utilityFunctions",
-    "functionsUnittests",
-    "jest.config.ts",
-    "jest.local.config.ts"
+    "utilityFunctions"
   ],
   "exclude": [
     "dist",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "functionsUnittests",
+    "jest.config.ts",
+    "jest.local.config.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- strip tests from main `tsconfig.json`
- add `tsconfig.test.json` for Jest
- configure Jest to use the test tsconfig

## Testing
- `npm run test:github`


------
https://chatgpt.com/codex/tasks/task_e_6882641cda3c832583804ca9733514b4