### PR TITLE
Add optional Allure report flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,12 @@ yarn add ts-functions-library
 # pnpm
 pnpm add ts-functions-library
 ```
-
 ## Usage
 Import the functions you need directly from the package root:
 
 ```ts
 import { chunkArray, deepMerge } from 'ts-functions-library';
 ```
-
 ## Directory Structure
 The main folders group functions by purpose:
 
@@ -49,7 +47,6 @@ Compile the TypeScript source with:
 ```bash
 npm run build
 ```
-
 This outputs compiled JavaScript files to the `dist/` directory. Ensure you have installed dependencies first with `npm install`.
 
 ## Testing
@@ -58,9 +55,15 @@ Jest is used for all unit tests. Run the full test suite with:
 ```bash
 npm test
 ```
-
 The command runs `run-tests.sh`, which executes Jest and generates an Allure report. Results are stored in `allure-results` and the final report in `allure-report`.
+By default the report is not opened automatically. Use the `--open-report` flag
+or set `OPEN_REPORT=true` to view the report after generation:
 
+```bash
+npm test -- --open-report
+# or
+OPEN_REPORT=true npm test
+```
 ## Contributing
 Contributions are welcome! Feel free to open issues or submit pull requests.
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -8,6 +8,17 @@ log_with_time() {
 
 log_with_time "[INFO] Running tests"
 
+# Default behavior does not open the Allure report. Use --open-report flag or
+# set OPEN_REPORT=true to automatically open it after generation.
+OPEN_REPORT_FLAG=false
+for arg in "$@"; do
+  case "$arg" in
+    --open-report)
+      OPEN_REPORT_FLAG=true
+      ;;
+  esac
+done
+
 # Ensure local node binaries are available
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 export PATH="$SCRIPT_DIR/node_modules/.bin:$PATH"
@@ -56,10 +67,14 @@ if ! allure generate allure-results --clean -o allure-report; then
   log_with_time "[ERROR] Failed to generate Allure report, but continuing with the script"
 fi
 
-# Open Allure report
-log_with_time "[INFO] Opening Allure report"
-if ! allure open allure-report; then
-  log_with_time "[ERROR] Failed to open Allure report, but continuing with the script"
+# Open Allure report if requested
+if [ "$OPEN_REPORT_FLAG" = "true" ] || [ "${OPEN_REPORT:-false}" = "true" ]; then
+  log_with_time "[INFO] Opening Allure report"
+  if ! allure open allure-report; then
+    log_with_time "[ERROR] Failed to open Allure report, but continuing with the script"
+  fi
+else
+  log_with_time "[INFO] Allure report not opened (use --open-report or set OPEN_REPORT=true)"
 fi
 
 log_with_time "[INFO] Test execution completed"


### PR DESCRIPTION
## Summary
- add optional `--open-report` flag or `OPEN_REPORT` env var to `run-tests.sh`
- update README with instructions on using the flag or environment variable

## Testing
- `npm test --silent -- --open-report` *(interrupted because Allure tries to open a server)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6882699231188325ba9a895247f035a4