### PR TITLE
Update ESLint to 9.32.0

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ const prettier = require('eslint-plugin-prettier');
 
 module.exports = [
   {
-    files: ['**/*.ts'],
+    files: ['**/*.ts', '!functionsUnittests/**/*.ts', '!jest*.ts'],
     languageOptions: {
       parser: tsParser,
       ecmaVersion: 2024,
@@ -78,6 +78,45 @@ module.exports = [
     },
   },
   {
-    ignores: ['node_modules/**', 'dist/**', 'coverage/**'],
+    files: ['functionsUnittests/**/*.ts', 'jest*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 2024,
+      sourceType: 'module',
+      parserOptions: {
+        project: './tsconfig.test.json',
+        tsconfigRootDir: __dirname,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+      'prettier': prettier,
+    },
+    rules: {
+      'prettier/prettier': ['error', {
+        singleQuote: true,
+        tabWidth: 2
+      }],
+      'no-console': 'warn',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': ['warn', { 'argsIgnorePattern': '^_' }],
+      '@typescript-eslint/no-floating-promises': 'warn',
+      '@typescript-eslint/no-unsafe-argument': 'warn',
+      '@typescript-eslint/require-await': 'error',
+      '@typescript-eslint/no-unsafe-assignment': 'warn',
+      '@typescript-eslint/no-unsafe-member-access': 'warn',
+      '@typescript-eslint/no-unsafe-call': 'warn',
+      '@typescript-eslint/no-unsafe-return': 'warn',
+      '@typescript-eslint/no-shadow': 'warn',
+      'no-duplicate-imports': 'warn',
+      '@typescript-eslint/no-useless-constructor': 'warn',
+      '@typescript-eslint/consistent-type-definitions': ['warn', 'interface'],
+      '@typescript-eslint/no-var-requires': 'error',
+      '@typescript-eslint/consistent-type-imports': 'warn',
+    },
+  },
+  {
+    ignores: ['node_modules/**', 'dist/**', 'coverage/**', 'allure-report/**', 'eslint.config.js'],
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@typescript-eslint/parser": "^8.38.0",
                 "allure-commandline": "^2.34.1",
                 "allure-jest": "^3.3.2",
-                "eslint": "^9.31.0",
+                "eslint": "^9.32.0",
                 "eslint-config-prettier": "^10.1.8",
                 "eslint-plugin-prettier": "^5.5.3",
                 "jest": "^30.0.5",
@@ -734,9 +734,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.31.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
-            "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
+            "version": "9.32.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
+            "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4066,9 +4066,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.31.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
-            "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
+            "version": "9.32.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
+            "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4078,8 +4078,8 @@
                 "@eslint/config-helpers": "^0.3.0",
                 "@eslint/core": "^0.15.0",
                 "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.31.0",
-                "@eslint/plugin-kit": "^0.3.1",
+                "@eslint/js": "9.32.0",
+                "@eslint/plugin-kit": "^0.3.4",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@typescript-eslint/parser": "^8.38.0",
         "allure-commandline": "^2.34.1",
         "allure-jest": "^3.3.2",
-        "eslint": "^9.31.0",
+        "eslint": "^9.32.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.3",
         "jest": "^30.0.5",


### PR DESCRIPTION
## Summary
- bump `eslint` to 9.32.0
- update `eslint.config.js` so test files lint correctly and ignore generated folders

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6886211086608325a7de3aba6a0c4afd