### PR TITLE
Update encodingFunctions bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The main folders group functions by purpose:
 - **objectFunctions** – utilities for manipulating objects including `deepMerge`, `safeGet`, and `groupByObject`. The `deepClone` helper now uses Node's `structuredClone` when available and falls back to JSON serialization in older environments.
 - **stringFunctions** – text related helpers like `slugify`, `trimWhitespace`, and `isValidEmail`.
 - **dateFunctions** – date utilities such as `formatDate`, `addMonths`, and `getWeekNumber`.
-- **encodingFunctions** – simple Base64 encoding/decoding helpers.
+- **encodingFunctions** – simple Base64 encoding/decoding helpers. `encodeBase64` and `decodeBase64` rely on Node's `Buffer`, so browsers may need alternatives like `btoa`/`atob`.
 - **mathFunctions** – mathematical helpers, including geometric calculations.
 - **utilityFunctions** – assorted utilities like `debounce`, `throttle`, and `hexToRgb`.
 


### PR DESCRIPTION
## Summary
- clarify that `encodeBase64` and `decodeBase64` use Node's `Buffer`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bd5907a9c83258a072eba778a25b4