### PR TITLE
Add unit tests for encoding and utility helpers

### DIFF
--- a/functionsUnittests/encodingFunctions/decodeBase64.test.ts
+++ b/functionsUnittests/encodingFunctions/decodeBase64.test.ts
@@ -1,0 +1,29 @@
+import { decodeBase64 } from '../../encodingFunctions/decodeBase64';
+
+describe('decodeBase64', () => {
+  // Test case 1: Decode a basic base64 string
+  it('1. should decode a basic base64 string', () => {
+    expect(decodeBase64('aGVsbG8gd29ybGQ=')).toBe('hello world');
+  });
+
+  // Test case 2: Decode an empty string
+  it('2. should decode an empty string', () => {
+    expect(decodeBase64('')).toBe('');
+  });
+
+  // Test case 3: Decode URL-safe base64 string
+  it('3. should decode a URL-safe base64 string', () => {
+    expect(decodeBase64('YWE_')).toBe('aa?');
+  });
+
+  // Test case 4: Decode unicode characters
+  it('4. should decode unicode characters', () => {
+    const encoded = '44GT44KT44Gr44Gh44Gv';
+    expect(decodeBase64(encoded)).toBe('こんにちは');
+  });
+
+  // Test case 5: Decode string without padding
+  it('5. should decode a string without padding', () => {
+    expect(decodeBase64('aGVsbG8gd29ybGQ')).toBe('hello world');
+  });
+});

--- a/functionsUnittests/encodingFunctions/encodeBase64.test.ts
+++ b/functionsUnittests/encodingFunctions/encodeBase64.test.ts
@@ -1,0 +1,28 @@
+import { encodeBase64 } from '../../encodingFunctions/encodeBase64';
+
+describe('encodeBase64', () => {
+  // Test case 1: Encode a simple string
+  it('1. should encode a simple string', () => {
+    expect(encodeBase64('hello world')).toBe('aGVsbG8gd29ybGQ');
+  });
+
+  // Test case 2: Encode an empty string
+  it('2. should encode an empty string', () => {
+    expect(encodeBase64('')).toBe('');
+  });
+
+  // Test case 3: Encode a string with special characters
+  it('3. should encode a string with special characters', () => {
+    expect(encodeBase64('?foo=bar')).toBe('P2Zvbz1iYXI');
+  });
+
+  // Test case 4: Encode unicode characters
+  it('4. should encode unicode characters', () => {
+    expect(encodeBase64('こんにちは')).toBe('44GT44KT44Gr44Gh44Gv');
+  });
+
+  // Test case 5: Replace "/" with "_" and remove padding
+  it('5. should replace "/" with "_" and remove padding', () => {
+    expect(encodeBase64('aa?')).toBe('YWE_');
+  });
+});

--- a/functionsUnittests/utilityFunctions/bytesToSize.test.ts
+++ b/functionsUnittests/utilityFunctions/bytesToSize.test.ts
@@ -1,0 +1,16 @@
+import { bytesToSize } from '../../utilityFunctions/bytesToSize';
+
+describe('bytesToSize', () => {
+  const cases: [number, string][] = [
+    [0, '0 Bytes'],
+    [512, '512.00 Bytes'],
+    [1023, '1023.00 Bytes'],
+    [1024, '1.00 KB'],
+    [1048576, '1.00 MB'],
+    [1073741824, '1.00 GB'],
+  ];
+
+  test.each(cases)('%#. converts %i bytes', (input, expected) => {
+    expect(bytesToSize(input)).toBe(expected);
+  });
+});

--- a/functionsUnittests/utilityFunctions/debounce.test.ts
+++ b/functionsUnittests/utilityFunctions/debounce.test.ts
@@ -1,0 +1,68 @@
+import { debounce } from '../../utilityFunctions/debounce';
+
+describe('debounce', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // Test case 1: Execute after delay
+  it('1. should execute after the specified delay', () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 50);
+    debounced();
+    expect(fn).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(50);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  // Test case 2: Execute only once for rapid calls
+  it('2. should execute only once for rapid calls', () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 50);
+    debounced();
+    debounced();
+    jest.advanceTimersByTime(50);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  // Test case 3: Use latest arguments
+  it('3. should use the latest arguments', () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 50);
+    debounced('first');
+    debounced('second');
+    jest.advanceTimersByTime(50);
+    expect(fn).toHaveBeenCalledWith('second');
+  });
+
+  // Test case 4: Preserve context
+  it('4. should preserve the context', () => {
+    const obj = {
+      count: 0,
+      inc(this: any, amount: number) {
+        this.count += amount;
+      },
+    };
+    const debounced = debounce(obj.inc, 50);
+    debounced.call(obj, 2);
+    jest.advanceTimersByTime(50);
+    expect(obj.count).toBe(2);
+  });
+
+  // Test case 5: Reset timer on successive calls
+  it('5. should reset the timer on successive calls', () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 50);
+    debounced();
+    jest.advanceTimersByTime(30);
+    debounced();
+    jest.advanceTimersByTime(30);
+    expect(fn).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(20);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/functionsUnittests/utilityFunctions/debounceAsync.test.ts
+++ b/functionsUnittests/utilityFunctions/debounceAsync.test.ts
@@ -1,0 +1,61 @@
+import { debounceAsync } from '../../utilityFunctions/debounceAsync';
+
+describe('debounceAsync', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // Test case 1: Resolve with function result after delay
+  it('1. should resolve with the function result after the delay', async () => {
+    const fn = jest.fn(async (n: number) => n * 2);
+    const debounced = debounceAsync(fn, 50);
+    const promise = debounced(2);
+    jest.advanceTimersByTime(50);
+    await expect(promise).resolves.toBe(4);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  // Test case 2: Execute only the last call
+  it('2. should execute only the last call made before the delay', async () => {
+    const fn = jest.fn(async (n: number) => n);
+    const debounced = debounceAsync(fn, 50);
+    debounced(1);
+    const promise = debounced(2);
+    jest.advanceTimersByTime(50);
+    await expect(promise).resolves.toBe(2);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  // Test case 3: Pass arguments correctly
+  it('3. should pass arguments correctly', async () => {
+    const fn = jest.fn(async (a: number, b: number) => a + b);
+    const debounced = debounceAsync(fn, 50);
+    const promise = debounced(1, 2);
+    jest.advanceTimersByTime(50);
+    await expect(promise).resolves.toBe(3);
+  });
+
+  // Test case 4: Propagate rejection
+  it('4. should propagate rejection from the underlying function', async () => {
+    const fn = jest.fn(async () => {
+      throw new Error('fail');
+    });
+    const debounced = debounceAsync(fn, 50);
+    const promise = debounced();
+    jest.advanceTimersByTime(50);
+    await expect(promise).rejects.toThrow('fail');
+  });
+
+  // Test case 5: Work with zero wait time
+  it('5. should work with zero wait time', async () => {
+    const fn = jest.fn(async () => 'done');
+    const debounced = debounceAsync(fn, 0);
+    const promise = debounced();
+    jest.runAllTimers();
+    await expect(promise).resolves.toBe('done');
+  });
+});

--- a/functionsUnittests/utilityFunctions/delay.test.ts
+++ b/functionsUnittests/utilityFunctions/delay.test.ts
@@ -1,0 +1,65 @@
+import { delay } from '../../utilityFunctions/delay';
+
+describe('delay', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // Test case 1: Resolve after specified delay
+  it('1. should resolve after the specified delay', async () => {
+    const spy = jest.fn();
+    const promise = delay(50).then(spy);
+    jest.advanceTimersByTime(50);
+    await promise;
+    expect(spy).toHaveBeenCalled();
+  });
+
+  // Test case 2: Resolve immediately for zero delay
+  it('2. should resolve immediately for zero delay', async () => {
+    const spy = jest.fn();
+    const promise = delay(0).then(spy);
+    jest.runAllTimers();
+    await promise;
+    expect(spy).toHaveBeenCalled();
+  });
+
+  // Test case 3: Work with async/await
+  it('3. should work with async/await', async () => {
+    const spy = jest.fn();
+    const asyncFunc = async () => {
+      await delay(30);
+      spy();
+    };
+    const promise = asyncFunc();
+    jest.advanceTimersByTime(30);
+    await promise;
+    expect(spy).toHaveBeenCalled();
+  });
+
+  // Test case 4: Multiple delays resolve independently
+  it('4. should allow multiple delays to resolve independently', async () => {
+    const spy1 = jest.fn();
+    const spy2 = jest.fn();
+    const p1 = delay(20).then(spy1);
+    const p2 = delay(40).then(spy2);
+    jest.advanceTimersByTime(20);
+    await p1;
+    expect(spy1).toHaveBeenCalled();
+    expect(spy2).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(20);
+    await p2;
+    expect(spy2).toHaveBeenCalled();
+  });
+
+  // Test case 5: Should not resolve before time
+  it('5. should not resolve before the specified time', () => {
+    const spy = jest.fn();
+    delay(50).then(spy);
+    jest.advanceTimersByTime(30);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/functionsUnittests/utilityFunctions/hexToRgb.test.ts
+++ b/functionsUnittests/utilityFunctions/hexToRgb.test.ts
@@ -1,0 +1,28 @@
+import { hexToRgb } from '../../utilityFunctions/hexToRgb';
+
+describe('hexToRgb', () => {
+  // Test case 1: Convert hex with hash prefix
+  it('1. should convert hex with hash prefix', () => {
+    expect(hexToRgb('#ff5733')).toEqual({ r: 255, g: 87, b: 51 });
+  });
+
+  // Test case 2: Convert hex without hash
+  it('2. should convert hex without hash', () => {
+    expect(hexToRgb('ff5733')).toEqual({ r: 255, g: 87, b: 51 });
+  });
+
+  // Test case 3: Convert black hex value
+  it('3. should convert black hex value', () => {
+    expect(hexToRgb('#000000')).toEqual({ r: 0, g: 0, b: 0 });
+  });
+
+  // Test case 4: Convert mixed hex value
+  it('4. should convert mixed hex value', () => {
+    expect(hexToRgb('#00ff0f')).toEqual({ r: 0, g: 255, b: 15 });
+  });
+
+  // Test case 5: Return null for invalid hex
+  it('5. should return null for invalid hex', () => {
+    expect(hexToRgb('#123')).toBeNull();
+  });
+});

--- a/functionsUnittests/utilityFunctions/isNil.test.ts
+++ b/functionsUnittests/utilityFunctions/isNil.test.ts
@@ -1,0 +1,28 @@
+import { isNil } from '../../utilityFunctions/isNil';
+
+describe('isNil', () => {
+  // Test case 1: null value
+  it('1. should return true for null', () => {
+    expect(isNil(null)).toBe(true);
+  });
+
+  // Test case 2: undefined value
+  it('2. should return true for undefined', () => {
+    expect(isNil(undefined)).toBe(true);
+  });
+
+  // Test case 3: zero value
+  it('3. should return false for zero', () => {
+    expect(isNil(0)).toBe(false);
+  });
+
+  // Test case 4: empty string
+  it('4. should return false for empty string', () => {
+    expect(isNil('')).toBe(false);
+  });
+
+  // Test case 5: object value
+  it('5. should return false for an object', () => {
+    expect(isNil({})).toBe(false);
+  });
+});

--- a/functionsUnittests/utilityFunctions/rgbToHex.test.ts
+++ b/functionsUnittests/utilityFunctions/rgbToHex.test.ts
@@ -1,0 +1,15 @@
+import { rgbToHex } from '../../utilityFunctions/rgbToHex';
+
+describe('rgbToHex', () => {
+  const cases: [{ r: number; g: number; b: number }, string][] = [
+    [{ r: 255, g: 87, b: 51 }, '#ff5733'],
+    [{ r: 0, g: 0, b: 0 }, '#000000'],
+    [{ r: 1, g: 2, b: 3 }, '#010203'],
+    [{ r: 16, g: 32, b: 48 }, '#102030'],
+    [{ r: 255, g: 255, b: 255 }, '#ffffff'],
+  ];
+
+  test.each(cases)('%#. converts %o to %s', (input, expected) => {
+    expect(rgbToHex(input)).toBe(expected);
+  });
+});

--- a/functionsUnittests/utilityFunctions/safeJSONParse.test.ts
+++ b/functionsUnittests/utilityFunctions/safeJSONParse.test.ts
@@ -1,0 +1,29 @@
+import { safeJSONParse } from '../../utilityFunctions/safeJSONParse';
+
+describe('safeJSONParse', () => {
+  // Test case 1: Parse valid JSON object
+  it('1. should parse a valid JSON object', () => {
+    const json = '{"name":"John"}';
+    expect(safeJSONParse(json, {})).toEqual({ name: 'John' });
+  });
+
+  // Test case 2: Return default for invalid JSON
+  it('2. should return default for invalid JSON', () => {
+    expect(safeJSONParse('invalid', { a: 1 })).toEqual({ a: 1 });
+  });
+
+  // Test case 3: Parse numeric JSON
+  it('3. should parse numeric JSON', () => {
+    expect(safeJSONParse('123', 0)).toBe(123);
+  });
+
+  // Test case 4: Parse JSON array
+  it('4. should parse a JSON array', () => {
+    expect(safeJSONParse('[1,2,3]', [])).toEqual([1, 2, 3]);
+  });
+
+  // Test case 5: Return default for empty string
+  it('5. should return default for empty string', () => {
+    expect(safeJSONParse('', { hello: 'world' })).toEqual({ hello: 'world' });
+  });
+});


### PR DESCRIPTION
## Summary
- add thorough tests for encodeBase64 and decodeBase64
- cover missing utility helpers: bytesToSize, debounce, debounceAsync, delay, hexToRgb, isNil, rgbToHex and safeJSONParse

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894e91896fc8325a9b2037edc87c5db