### PR TITLE
feat: validate base64 input

### DIFF
--- a/encodingFunctions/decodeBase64.ts
+++ b/encodingFunctions/decodeBase64.ts
@@ -8,10 +8,25 @@ import { Buffer } from 'buffer';
  *
  * @param str - The base64 encoded string to decode.
  * @returns The decoded string.
+ * @throws {Error} If the provided string is not valid base64.
  *
  * @example
  * decodeBase64("aGVsbG8gd29ybGQ="); // "hello world"
  */
 export function decodeBase64(str: string): string {
-  return Buffer.from(str, 'base64').toString('utf-8');
+  try {
+    const normalized = str.replace(/-/g, '+').replace(/_/g, '/');
+    const buffer = Buffer.from(normalized, 'base64');
+    const decoded = buffer.toString('utf-8');
+    const reEncoded = buffer.toString('base64').replace(/=+$/, '');
+    const sanitizedInput = normalized.replace(/=+$/, '');
+
+    if (reEncoded !== sanitizedInput) {
+      throw new Error('Invalid base64 string');
+    }
+
+    return decoded;
+  } catch {
+    throw new Error('Invalid base64 string');
+  }
 }

--- a/functionsUnittests/encodingFunctions/decodeBase64.test.ts
+++ b/functionsUnittests/encodingFunctions/decodeBase64.test.ts
@@ -26,4 +26,9 @@ describe('decodeBase64', () => {
   it('5. should decode a string without padding', () => {
     expect(decodeBase64('aGVsbG8gd29ybGQ')).toBe('hello world');
   });
+
+  // Test case 6: Handle invalid base64 string
+  it('6. should throw an error for invalid base64', () => {
+    expect(() => decodeBase64('@@')).toThrow('Invalid base64 string');
+  });
 });


### PR DESCRIPTION
## Summary
- detect invalid base64 in `decodeBase64`
- test invalid base64 handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894f00f69148325b2710d80c69878b1