### PR TITLE
Clamp rgb channels and test bounds in rgbToHex

### DIFF
--- a/functionsUnittests/utilityFunctions/rgbToHex.test.ts
+++ b/functionsUnittests/utilityFunctions/rgbToHex.test.ts
@@ -7,6 +7,8 @@ describe('rgbToHex', () => {
     [{ r: 1, g: 2, b: 3 }, '#010203'],
     [{ r: 16, g: 32, b: 48 }, '#102030'],
     [{ r: 255, g: 255, b: 255 }, '#ffffff'],
+    [{ r: -1, g: -20, b: -300 }, '#000000'],
+    [{ r: 256, g: 300, b: 999 }, '#ffffff'],
   ];
 
   test.each(cases)('%#. converts %o to %s', (input, expected) => {

--- a/utilityFunctions/rgbToHex.ts
+++ b/utilityFunctions/rgbToHex.ts
@@ -13,6 +13,7 @@
  * @complexity O(1)
  */
 export function rgbToHex(rgb: { r: number; g: number; b: number }): string {
-  const toHex = (num: number) => num.toString(16).padStart(2, '0');
+  const clamp = (num: number) => Math.min(255, Math.max(0, Math.round(num)));
+  const toHex = (num: number) => clamp(num).toString(16).padStart(2, '0');
   return `#${toHex(rgb.r)}${toHex(rgb.g)}${toHex(rgb.b)}`;
 }


### PR DESCRIPTION
## Summary
- clamp RGB values to the 0-255 range before conversion
- add unit tests for negative and overflow inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894f01509ac8325b1c3b11fa7c50ba2