### PR TITLE
test: check hexToRgb invalid characters

### DIFF
--- a/functionsUnittests/utilityFunctions/hexToRgb.test.ts
+++ b/functionsUnittests/utilityFunctions/hexToRgb.test.ts
@@ -25,4 +25,9 @@ describe('hexToRgb', () => {
   it('5. should return null for invalid hex', () => {
     expect(hexToRgb('#123')).toBeNull();
   });
+
+  // Test case 6: Return null for invalid hex characters
+  it('6. should return null for invalid hex characters', () => {
+    expect(hexToRgb('#zzzzzz')).toBeNull();
+  });
 });

--- a/utilityFunctions/hexToRgb.ts
+++ b/utilityFunctions/hexToRgb.ts
@@ -17,7 +17,7 @@ export function hexToRgb(
   hex: string,
 ): { r: number; g: number; b: number } | null {
   const hexValue = hex.replace(/^#/, '');
-  if (hexValue.length !== 6) return null;
+  if (!/^[\da-fA-F]{6}$/.test(hexValue)) return null;
 
   const bigint = parseInt(hexValue, 16);
   const r = (bigint >> 16) & 255;


### PR DESCRIPTION
## Summary
- ensure hexToRgb only parses valid six-digit hex strings
- add test verifying '#zzzzzz' returns null

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894f016e8bc83259ee1aaceb8d8ba05