### PR TITLE
Handle empty segments in parseQueryString

### DIFF
--- a/functionsUnittests/utilityFunctions/parseQueryString.test.ts
+++ b/functionsUnittests/utilityFunctions/parseQueryString.test.ts
@@ -54,4 +54,20 @@ describe('parseQueryString', () => {
     const expected = { a: '2' };
     expect(result).toEqual(expected);
   });
+
+  // Test case 8: Handle keys with empty values
+  it("8. should parse keys with empty values", () => {
+    const queryString = '?flag=';
+    const result = parseQueryString(queryString);
+    const expected = { flag: '' };
+    expect(result).toEqual(expected);
+  });
+
+  // Test case 9: Ignore empty segments
+  it('9. should ignore empty segments', () => {
+    const queryString = 'name=John&&age=30';
+    const result = parseQueryString(queryString);
+    const expected = { name: 'John', age: '30' };
+    expect(result).toEqual(expected);
+  });
 });

--- a/utilityFunctions/parseQueryString.ts
+++ b/utilityFunctions/parseQueryString.ts
@@ -22,9 +22,13 @@ export function parseQueryString(queryString: string): Record<string, string> {
     .replace(/^\?/, '')
     .replace(/\+/g, ' ')
     .split('&')
+    .filter(Boolean)
     .reduce(
       (acc, queryParam) => {
         const [key, value] = queryParam.split('=');
+        if (!key) {
+          return acc;
+        }
         acc[decodeURIComponent(key)] = decodeURIComponent(value || '');
         return acc;
       },


### PR DESCRIPTION
## Summary
- Ignore empty query string segments in parseQueryString to prevent empty keys
- Add tests for empty-value parameters and consecutive ampersands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894f018130c8325bdbc17af397fbad3