### PR TITLE
test: add default return cases for safeJSONParse

### DIFF
--- a/functionsUnittests/utilityFunctions/safeJSONParse.test.ts
+++ b/functionsUnittests/utilityFunctions/safeJSONParse.test.ts
@@ -26,4 +26,14 @@ describe('safeJSONParse', () => {
   it('5. should return default for empty string', () => {
     expect(safeJSONParse('', { hello: 'world' })).toEqual({ hello: 'world' });
   });
+
+  // Test case 6: Return null for invalid JSON
+  it('6. should return null for invalid JSON', () => {
+    expect(safeJSONParse('invalid', null)).toBeNull();
+  });
+
+  // Test case 7: Return false for invalid JSON
+  it('7. should return false for invalid JSON', () => {
+    expect(safeJSONParse('invalid', false)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- extend safeJSONParse tests to cover null and false defaults when parsing invalid JSON

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894f018b10c8325b4a2146e19779da0