### PR TITLE
test: expand decode and utility coverage

### DIFF
--- a/functionsUnittests/encodingFunctions/decodeBase64.test.ts
+++ b/functionsUnittests/encodingFunctions/decodeBase64.test.ts
@@ -36,4 +36,15 @@ describe('decodeBase64', () => {
   it('7. should throw an error for base64 with whitespace', () => {
     expect(() => decodeBase64('aGVsbG8g d29ybGQ=')).toThrow('Invalid base64 string');
   });
+
+  // Test case 8: Reject base64 strings with newlines
+  it('8. should throw an error for base64 with newlines', () => {
+    const encodedWithNewline = 'aGVsbG8gd29y\nbGQ=';
+    expect(() => decodeBase64(encodedWithNewline)).toThrow('Invalid base64 string');
+  });
+
+  // Test case 9: Reject base64 strings with invalid length
+  it('9. should throw an error for base64 with invalid length', () => {
+    expect(() => decodeBase64('Y')).toThrow('Invalid base64 string');
+  });
 });

--- a/functionsUnittests/utilityFunctions/parseQueryString.test.ts
+++ b/functionsUnittests/utilityFunctions/parseQueryString.test.ts
@@ -70,4 +70,20 @@ describe('parseQueryString', () => {
     const expected = { name: 'John', age: '30' };
     expect(result).toEqual(expected);
   });
+
+  // Test case 10: Decode plus sign when percent-encoded
+  it('10. should decode a percent-encoded plus sign', () => {
+    const queryString = '?a=%2B';
+    const result = parseQueryString(queryString);
+    const expected = { a: '+' };
+    expect(result).toEqual(expected);
+  });
+
+  // Test case 11: Ignore parameters without keys
+  it('11. should ignore parameters without keys', () => {
+    const queryString = '?=value&name=John';
+    const result = parseQueryString(queryString);
+    const expected = { name: 'John' };
+    expect(result).toEqual(expected);
+  });
 });

--- a/functionsUnittests/utilityFunctions/safeJSONParse.test.ts
+++ b/functionsUnittests/utilityFunctions/safeJSONParse.test.ts
@@ -46,4 +46,15 @@ describe('safeJSONParse', () => {
   it('9. should parse JSON with surrounding whitespace', () => {
     expect(safeJSONParse('  {"a":1}  ', {})).toEqual({ a: 1 });
   });
+
+  // Test case 10: Parse JSON literal null
+  it('10. should parse JSON literal null', () => {
+    expect(safeJSONParse('null', 'default')).toBeNull();
+  });
+
+  // Test case 11: Parse nested JSON object
+  it('11. should parse a nested JSON object', () => {
+    const json = '{"user":{"name":"John"}}';
+    expect(safeJSONParse(json, {})).toEqual({ user: { name: 'John' } });
+  });
 });


### PR DESCRIPTION
## Summary
- add newline and length validation tests for `decodeBase64`
- broaden `parseQueryString` tests for percent-encoded plus signs and keyless params
- extend `safeJSONParse` tests for null literal and nested objects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689502247ea08325bef02c6e31bc5908