### PR TITLE
test: expand encoding and utility coverage

### DIFF
--- a/functionsUnittests/encodingFunctions/encodeBase64.test.ts
+++ b/functionsUnittests/encodingFunctions/encodeBase64.test.ts
@@ -21,18 +21,28 @@ describe('encodeBase64', () => {
     expect(encodeBase64('こんにちは')).toBe('44GT44KT44Gr44Gh44Gv');
   });
 
-  // Test case 5: Replace "/" with "_" and remove padding
-  it('5. should replace "/" with "_" and remove padding', () => {
+  // Test case 5: Encode string with emoji characters
+  it('5. should encode string with emoji characters', () => {
+    expect(encodeBase64('😀')).toBe('8J-YgA');
+  });
+
+  // Test case 6: Encode a string with punctuation
+  it('6. should encode a string with punctuation', () => {
+    expect(encodeBase64('Hello, World!')).toBe('SGVsbG8sIFdvcmxkIQ');
+  });
+
+  // Test case 7: Replace "/" with "_" and remove padding
+  it('7. should replace "/" with "_" and remove padding', () => {
     expect(encodeBase64('aa?')).toBe('YWE_');
   });
 
-  // Test case 6: Replace "+" with "-" and remove padding
-  it('6. should replace "+" with "-" and remove padding', () => {
+  // Test case 8: Replace "+" with "-" and remove padding
+  it('8. should replace "+" with "-" and remove padding', () => {
     expect(encodeBase64(String.fromCharCode(0xF8))).toBe('-A');
   });
 
-  // Test case 7: Remove all trailing "=" characters
-  it('7. should remove all trailing "=" characters', () => {
+  // Test case 9: Remove all trailing "=" characters
+  it('9. should remove all trailing "=" characters', () => {
     expect(encodeBase64('a')).toBe('YQ');
   });
 });

--- a/functionsUnittests/utilityFunctions/hexToRgb.test.ts
+++ b/functionsUnittests/utilityFunctions/hexToRgb.test.ts
@@ -21,13 +21,23 @@ describe('hexToRgb', () => {
     expect(hexToRgb('#00ff0f')).toEqual({ r: 0, g: 255, b: 15 });
   });
 
-  // Test case 5: Return null for invalid hex
-  it('5. should return null for invalid hex', () => {
+  // Test case 5: Convert uppercase hex value
+  it('5. should convert uppercase hex value', () => {
+    expect(hexToRgb('#ABCDEF')).toEqual({ r: 171, g: 205, b: 239 });
+  });
+
+  // Test case 6: Return null for invalid hex
+  it('6. should return null for invalid hex', () => {
     expect(hexToRgb('#123')).toBeNull();
   });
 
-  // Test case 6: Return null for invalid hex characters
-  it('6. should return null for invalid hex characters', () => {
+  // Test case 7: Return null for invalid hex characters
+  it('7. should return null for invalid hex characters', () => {
     expect(hexToRgb('#zzzzzz')).toBeNull();
+  });
+
+  // Test case 8: Return null for hex string longer than 6 digits
+  it('8. should return null for hex string longer than 6 digits', () => {
+    expect(hexToRgb('#1234567')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- broaden encodeBase64 tests with emoji and punctuation scenarios
- extend hexToRgb tests with uppercase values and invalid length cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68950470d7fc8325a86dca5cf5bc0401