### PR TITLE
chore: standardize object test numbering

### DIFF
--- a/functionsUnittests/objectFunctions/compactObject.test.ts
+++ b/functionsUnittests/objectFunctions/compactObject.test.ts
@@ -2,7 +2,7 @@ import { compactObject } from '../../objectFunctions/compactObject';
 
 describe('compactObject', () => {
   // Test case 1: Remove null and undefined values
-  it('Test case 1: should remove null and undefined values', () => {
+  it('1. should remove null and undefined values', () => {
     const obj = { a: 1, b: null, c: undefined, d: 'string' };
     const result = compactObject(obj);
     const expected = { a: 1, d: 'string' };
@@ -10,7 +10,7 @@ describe('compactObject', () => {
   });
 
   // Test case 2: Handle object with no null or undefined values
-  it('Test case 2: should return the same object if there are no null or undefined values', () => {
+  it('2. should return the same object if there are no null or undefined values', () => {
     const obj = { a: 1, b: 'string', c: true };
     const result = compactObject(obj);
     const expected = { a: 1, b: 'string', c: true };
@@ -18,7 +18,7 @@ describe('compactObject', () => {
   });
 
   // Test case 3: Handle object with all null or undefined values
-  it('Test case 3: should return an empty object if all values are null or undefined', () => {
+  it('3. should return an empty object if all values are null or undefined', () => {
     const obj = { a: null, b: undefined };
     const result = compactObject(obj);
     const expected = {};
@@ -26,7 +26,7 @@ describe('compactObject', () => {
   });
 
   // Test case 4: Handle empty object
-  it('Test case 4: should return an empty object for an empty object', () => {
+  it('4. should return an empty object for an empty object', () => {
     const obj = {};
     const result = compactObject(obj);
     const expected = {};
@@ -34,7 +34,7 @@ describe('compactObject', () => {
   });
 
   // Test case 5: Handle object with nested null or undefined values
-  it('Test case 5: should remove nested null or undefined values', () => {
+  it('5. should remove nested null or undefined values', () => {
     const obj = { a: { b: null, c: 1 }, d: undefined, e: 'string' };
     const result = compactObject(obj);
     const expected = { a: { c: 1 }, e: 'string' };
@@ -42,7 +42,7 @@ describe('compactObject', () => {
   });
 
   // Test case 6: Handle object with array values
-  it('Test case 6: should handle object with array values', () => {
+  it('6. should handle object with array values', () => {
     const obj = { a: [1, 2, null], b: undefined, c: 'string' };
     const result = compactObject(obj);
     const expected = { a: [1, 2, null], c: 'string' };
@@ -50,7 +50,7 @@ describe('compactObject', () => {
   });
 
   // Test case 7: Handle object with function values
-  it('Test case 7: should handle object with function values', () => {
+  it('7. should handle object with function values', () => {
     const obj = { a: () => {}, b: null, c: 'string' };
     const result = compactObject(obj);
     const expected = { a: obj.a, c: 'string' };
@@ -58,7 +58,7 @@ describe('compactObject', () => {
   });
 
   // Test case 8: Handle object with symbol values
-  it('Test case 8: should handle object with symbol values', () => {
+  it('8. should handle object with symbol values', () => {
     const sym = Symbol('sym');
     const obj = { a: sym, b: null, c: 'string' };
     const result = compactObject(obj);
@@ -67,7 +67,7 @@ describe('compactObject', () => {
   });
 
   // Test case 9: Handle object with BigInt values
-  it('Test case 9: should handle object with BigInt values', () => {
+  it('9. should handle object with BigInt values', () => {
     const obj = { a: BigInt(123), b: null, c: 'string' };
     const result = compactObject(obj);
     const expected = { a: BigInt(123), c: 'string' };
@@ -75,27 +75,27 @@ describe('compactObject', () => {
   });
 
   // Test case 10: Handle non-object input (number)
-  it('Test case 10: should throw a TypeError if input is a number', () => {
+  it('10. should throw a TypeError if input is a number', () => {
     expect(() => compactObject(42 as any)).toThrow(TypeError);
   });
 
   // Test case 11: Handle non-object input (string)
-  it('Test case 11: should throw a TypeError if input is a string', () => {
+  it('11. should throw a TypeError if input is a string', () => {
     expect(() => compactObject('string' as any)).toThrow(TypeError);
   });
 
   // Test case 12: Handle non-object input (boolean)
-  it('Test case 12: should throw a TypeError if input is a boolean', () => {
+  it('12. should throw a TypeError if input is a boolean', () => {
     expect(() => compactObject(true as any)).toThrow(TypeError);
   });
 
   // Test case 13: Handle null input
-  it('Test case 13: should throw a TypeError if input is null', () => {
+  it('13. should throw a TypeError if input is null', () => {
     expect(() => compactObject(null as any)).toThrow(TypeError);
   });
 
   // Test case 14: Handle undefined input
-  it('Test case 14: should throw a TypeError if input is undefined', () => {
+  it('14. should throw a TypeError if input is undefined', () => {
     expect(() => compactObject(undefined as any)).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/entriesToObject.test.ts
+++ b/functionsUnittests/objectFunctions/entriesToObject.test.ts
@@ -2,7 +2,7 @@ import { entriesToObject } from '../../objectFunctions/entriesToObject';
 
 describe('entriesToObject', () => {
   // Test case 1: Convert valid entries to an object
-  it('Test case 1: should convert valid entries to an object', () => {
+  it('1. should convert valid entries to an object', () => {
     const entries: [string, number][] = [
       ['a', 1],
       ['b', 2],
@@ -14,7 +14,7 @@ describe('entriesToObject', () => {
   });
 
   // Test case 2: Handle empty entries array
-  it('Test case 2: should return an empty object for an empty entries array', () => {
+  it('2. should return an empty object for an empty entries array', () => {
     const entries: [string, unknown][] = [];
     const result = entriesToObject(entries);
     const expected = {};
@@ -22,7 +22,7 @@ describe('entriesToObject', () => {
   });
 
   // Test case 8: Handle entries with duplicate keys
-  it('Test case 3: should use the last value for duplicate keys', () => {
+  it('3. should use the last value for duplicate keys', () => {
     const entries: [string, number][] = [
       ['a', 1],
       ['b', 2],
@@ -34,7 +34,7 @@ describe('entriesToObject', () => {
   });
 
   // Test case 9: Handle entries with various value types
-  it('Test case 4: should handle entries with various value types', () => {
+  it('4. should handle entries with various value types', () => {
     const entries: [string, number | string | boolean | null | undefined][] = [
       ['a', 1],
       ['b', 'string'],
@@ -48,13 +48,13 @@ describe('entriesToObject', () => {
   });
 
   // Test case 3: Handle entries with non-string keys
-  it('Test case 5: should throw a TypeError if an entry has a non-string key', () => {
+  it('5. should throw a TypeError if an entry has a non-string key', () => {
     const entries: [string, unknown][] = [[123 as unknown as string, 'value']];
     expect(() => entriesToObject(entries)).toThrow(TypeError);
   });
 
   // Test case 4: Handle entries with invalid structure
-  it('Test case 6: should throw a TypeError if an entry is not a [string, any] pair', () => {
+  it('6. should throw a TypeError if an entry is not a [string, any] pair', () => {
     const entries: unknown[] = [['a', 1], ['b'], 'invalid'];
     expect(() =>
       entriesToObject(entries as unknown as [string, unknown][]),
@@ -62,21 +62,21 @@ describe('entriesToObject', () => {
   });
 
   // Test case 5: Handle non-array input
-  it('Test case 7: should throw a TypeError if input is not an array', () => {
+  it('7. should throw a TypeError if input is not an array', () => {
     expect(() => entriesToObject(42 as unknown as [string, unknown][])).toThrow(
       TypeError,
     );
   });
 
   // Test case 6: Handle null input
-  it('Test case 8: should throw a TypeError if input is null', () => {
+  it('8. should throw a TypeError if input is null', () => {
     expect(() =>
       entriesToObject(null as unknown as [string, unknown][]),
     ).toThrow(TypeError);
   });
 
   // Test case 7: Handle undefined input
-  it('Test case 9: should throw a TypeError if input is undefined', () => {
+  it('9. should throw a TypeError if input is undefined', () => {
     expect(() =>
       entriesToObject(undefined as unknown as [string, unknown][]),
     ).toThrow(TypeError);

--- a/functionsUnittests/objectFunctions/groupBy.test.ts
+++ b/functionsUnittests/objectFunctions/groupBy.test.ts
@@ -2,7 +2,7 @@ import { groupBy } from '../../objectFunctions/groupBy';
 
 describe('groupBy', () => {
   // Test case 1: Group by a string key
-  it('Test case 1: should group by a string key', () => {
+  it('1. should group by a string key', () => {
     const array = [
       { category: 'fruit', name: 'apple' },
       { category: 'fruit', name: 'banana' },
@@ -20,7 +20,7 @@ describe('groupBy', () => {
   });
 
   // Test case 2: Group by a number key
-  it('Test case 2: should group by a number key', () => {
+  it('2. should group by a number key', () => {
     const array = [
       { id: 1, name: 'apple' },
       { id: 2, name: 'banana' },
@@ -38,7 +38,7 @@ describe('groupBy', () => {
   });
 
   // Test case 3: Group by a boolean key
-  it('Test case 3: should group by a boolean key', () => {
+  it('3. should group by a boolean key', () => {
     const array = [
       { isFruit: true, name: 'apple' },
       { isFruit: true, name: 'banana' },
@@ -56,7 +56,7 @@ describe('groupBy', () => {
   });
 
   // Test case 4: Group by a key with undefined values
-  it('Test case 4: should group by a key with undefined values', () => {
+  it('4. should group by a key with undefined values', () => {
     const array = [
       { category: 'fruit', name: 'apple' },
       { category: undefined, name: 'banana' },
@@ -72,7 +72,7 @@ describe('groupBy', () => {
   });
 
   // Test case 5: Group by a key with null values
-  it('Test case 5: should group by a key with null values', () => {
+  it('5. should group by a key with null values', () => {
     const array = [
       { category: 'fruit', name: 'apple' },
       { category: null, name: 'banana' },
@@ -88,7 +88,7 @@ describe('groupBy', () => {
   });
 
   // Test case 6: Handle empty array
-  it('Test case 6: should return an empty object for an empty array', () => {
+  it('6. should return an empty object for an empty array', () => {
     const array: Array<Record<string, unknown>> = [];
     const result = groupBy(array, 'category');
     const expected = {};
@@ -96,7 +96,7 @@ describe('groupBy', () => {
   });
 
   // Test case 7: Handle array with no matching key
-  it('Test case 7: should return an empty object if key does not exist', () => {
+  it('7. should return an empty object if key does not exist', () => {
     const array = [
       { category: 'fruit', name: 'apple' },
       { category: 'fruit', name: 'banana' },
@@ -108,7 +108,7 @@ describe('groupBy', () => {
   });
 
   // Test case 8: Handle array with mixed types
-  it('Test case 8: should group by a key with mixed types', () => {
+  it('8. should group by a key with mixed types', () => {
     const array = [
       { category: 'fruit', name: 'apple' },
       { category: 1, name: 'banana' },
@@ -124,14 +124,14 @@ describe('groupBy', () => {
   });
 
   // Test case 9: Handle non-array input (number)
-  it('Test case 9: should throw a TypeError if input is not an array', () => {
+  it('9. should throw a TypeError if input is not an array', () => {
     expect(() =>
       groupBy(42 as unknown as Array<Record<string, unknown>>, 'category'),
     ).toThrow(TypeError);
   });
 
   // Test case 10: Handle non-array input (string)
-  it('Test case 10: should throw a TypeError if input is a string', () => {
+  it('10. should throw a TypeError if input is a string', () => {
     expect(() =>
       groupBy(
         'string' as unknown as Array<Record<string, unknown>>,
@@ -141,21 +141,21 @@ describe('groupBy', () => {
   });
 
   // Test case 11: Handle non-array input (boolean)
-  it('Test case 11: should throw a TypeError if input is a boolean', () => {
+  it('11. should throw a TypeError if input is a boolean', () => {
     expect(() =>
       groupBy(true as unknown as Array<Record<string, unknown>>, 'category'),
     ).toThrow(TypeError);
   });
 
   // Test case 12: Handle null input
-  it('Test case 12: should throw a TypeError if input is null', () => {
+  it('12. should throw a TypeError if input is null', () => {
     expect(() =>
       groupBy(null as unknown as Array<Record<string, unknown>>, 'category'),
     ).toThrow(TypeError);
   });
 
   // Test case 13: Handle undefined input
-  it('Test case 13: should throw a TypeError if input is undefined', () => {
+  it('13. should throw a TypeError if input is undefined', () => {
     expect(() =>
       groupBy(
         undefined as unknown as Array<Record<string, unknown>>,

--- a/functionsUnittests/objectFunctions/isDeepSubset.test.ts
+++ b/functionsUnittests/objectFunctions/isDeepSubset.test.ts
@@ -2,7 +2,7 @@ import { isDeepSubset } from '../../objectFunctions/isDeepSubset';
 
 describe('isDeepSubset', () => {
   // Test case 1: Subset matches the object
-  it('Test case 1: should return true if subset matches the object', () => {
+  it('1. should return true if subset matches the object', () => {
     const subset = { a: 1, b: 2 };
     const obj = { a: 1, b: 2, c: 3 };
     const result = isDeepSubset(subset, obj);
@@ -10,7 +10,7 @@ describe('isDeepSubset', () => {
   });
 
   // Test case 2: Subset does not match the object
-  it('Test case 2: should return false if subset does not match the object', () => {
+  it('2. should return false if subset does not match the object', () => {
     const subset = { a: 1, b: 4 };
     const obj = { a: 1, b: 2, c: 3 };
     const result = isDeepSubset(subset, obj);
@@ -18,7 +18,7 @@ describe('isDeepSubset', () => {
   });
 
   // Test case 3: Nested subset matches the object
-  it('Test case 3: should return true if nested subset matches the object', () => {
+  it('3. should return true if nested subset matches the object', () => {
     const subset = { a: { b: 2 } };
     const obj = { a: { b: 2, c: 3 }, d: 4 };
     const result = isDeepSubset(subset, obj);
@@ -26,7 +26,7 @@ describe('isDeepSubset', () => {
   });
 
   // Test case 4: Nested subset does not match the object
-  it('Test case 4: should return false if nested subset does not match the object', () => {
+  it('4. should return false if nested subset does not match the object', () => {
     const subset = { a: { b: 5 } };
     const obj = { a: { b: 2, c: 3 }, d: 4 };
     const result = isDeepSubset(subset, obj);
@@ -34,7 +34,7 @@ describe('isDeepSubset', () => {
   });
 
   // Test case 5: Empty subset
-  it('Test case 5: should return true if subset is empty', () => {
+  it('5. should return true if subset is empty', () => {
     const subset = {};
     const obj = { a: 1, b: 2 };
     const result = isDeepSubset(subset, obj);
@@ -42,7 +42,7 @@ describe('isDeepSubset', () => {
   });
 
   // Test case 6: Subset with null values
-  it('Test case 6: should return true if subset with null values matches the object', () => {
+  it('6. should return true if subset with null values matches the object', () => {
     const subset = { a: null };
     const obj = { a: null, b: 2 };
     const result = isDeepSubset(subset, obj);
@@ -50,7 +50,7 @@ describe('isDeepSubset', () => {
   });
 
   // Test case 7: Subset with undefined values
-  it('Test case 7: should return false if subset with undefined values does not match the object', () => {
+  it('7. should return false if subset with undefined values does not match the object', () => {
     const subset = { a: undefined } as any;
     const obj = { a: 1, b: 2 };
     const result = isDeepSubset(subset, obj);
@@ -58,7 +58,7 @@ describe('isDeepSubset', () => {
   });
 
   // Test case 8: Subset with array values
-  it('Test case 8: should return true if subset with array values matches the object', () => {
+  it('8. should return true if subset with array values matches the object', () => {
     const subset = { a: [1, 2] };
     const obj = { a: [1, 2, 3], b: 4 };
     const result = isDeepSubset(subset, obj);
@@ -66,7 +66,7 @@ describe('isDeepSubset', () => {
   });
 
   // Test case 9: Subset with mismatched array values
-  it('Test case 9: should return false if subset with array values does not match the object', () => {
+  it('9. should return false if subset with array values does not match the object', () => {
     const subset = { a: [1, 3] };
     const obj = { a: [1, 2, 3], b: 4 };
     const result = isDeepSubset(subset, obj);
@@ -74,7 +74,7 @@ describe('isDeepSubset', () => {
   });
 
   // Test case 10: Subset with nested arrays
-  it('Test case 10: should return true if subset with nested arrays matches the object', () => {
+  it('10. should return true if subset with nested arrays matches the object', () => {
     const subset = { a: { b: [1, 2] } };
     const obj = { a: { b: [1, 2, 3] }, c: 4 };
     const result = isDeepSubset(subset, obj);
@@ -82,7 +82,7 @@ describe('isDeepSubset', () => {
   });
 
   // Test case 11: Subset with mismatched nested arrays
-  it('Test case 11: should return false if subset with nested arrays does not match the object', () => {
+  it('11. should return false if subset with nested arrays does not match the object', () => {
     const subset = { a: { b: [1, 4] } };
     const obj = { a: { b: [1, 2, 3] }, c: 4 };
     const result = isDeepSubset(subset, obj);
@@ -90,7 +90,7 @@ describe('isDeepSubset', () => {
   });
 
   // Test case 12: Subset with different data types
-  it('Test case 12: should return false if subset has mismatched data types', () => {
+  it('12. should return false if subset has mismatched data types', () => {
     const subset = { a: '1' } as any;
     const obj = { a: 1, b: 2 };
     const result = isDeepSubset(subset, obj);
@@ -98,7 +98,7 @@ describe('isDeepSubset', () => {
   });
 
   // Test case 13: Subset with additional keys in the object
-  it('Test case 13: should return true if subset matches even with additional keys in the object', () => {
+  it('13. should return true if subset matches even with additional keys in the object', () => {
     const subset = { a: 1 };
     const obj = { a: 1, b: 2, c: 3 };
     const result = isDeepSubset(subset, obj);
@@ -106,7 +106,7 @@ describe('isDeepSubset', () => {
   });
 
   // Test case 14: Subset with empty nested object
-  it('Test case 14: should return true if subset has an empty nested object', () => {
+  it('14. should return true if subset has an empty nested object', () => {
     const subset = { a: {} };
     const obj = { a: { b: 1 }, c: 2 };
     const result = isDeepSubset(subset, obj);
@@ -114,7 +114,7 @@ describe('isDeepSubset', () => {
   });
 
   // Test case 15: Subset with mismatched nested object
-  it('Test case 15: should return false if subset has a mismatched nested object', () => {
+  it('15. should return false if subset has a mismatched nested object', () => {
     const subset = { a: { b: 2 } };
     const obj = { a: { b: 1 }, c: 2 };
     const result = isDeepSubset(subset, obj);
@@ -122,7 +122,7 @@ describe('isDeepSubset', () => {
   });
 
   // Test case 16: Subset with deep nesting
-  it('Test case 16: should return true if deeply nested subset matches the object', () => {
+  it('16. should return true if deeply nested subset matches the object', () => {
     const subset = { a: { b: { c: { d: 1 } } } };
     const obj = { a: { b: { c: { d: 1, e: 2 } }, f: 3 }, g: 4 };
     const result = isDeepSubset(subset, obj);
@@ -130,7 +130,7 @@ describe('isDeepSubset', () => {
   });
 
   // Test case 17: Subset with mismatched deep nesting
-  it('Test case 17: should return false if deeply nested subset does not match the object', () => {
+  it('17. should return false if deeply nested subset does not match the object', () => {
     const subset = { a: { b: { c: { d: 2 } } } };
     const obj = { a: { b: { c: { d: 1, e: 2 } }, f: 3 }, g: 4 };
     const result = isDeepSubset(subset, obj);
@@ -139,17 +139,17 @@ describe('isDeepSubset', () => {
 
   // Error-handling test cases
   // Test case 18: Handle non-object subset
-  it('Test case 18: should throw a TypeError if subset is not an object', () => {
+  it('18. should throw a TypeError if subset is not an object', () => {
     expect(() => isDeepSubset(null as any, { a: 1 })).toThrow(TypeError);
   });
 
   // Test case 19: Handle non-object obj
-  it('Test case 19: should throw a TypeError if obj is not an object', () => {
+  it('19. should throw a TypeError if obj is not an object', () => {
     expect(() => isDeepSubset({ a: 1 }, null as any)).toThrow(TypeError);
   });
 
   // Test case 20: Handle both subset and obj as non-objects
-  it('Test case 20: should throw a TypeError if both subset and obj are not objects', () => {
+  it('20. should throw a TypeError if both subset and obj are not objects', () => {
     expect(() => isDeepSubset(null as any, null as any)).toThrow(TypeError);
   });
 });

--- a/functionsUnittests/objectFunctions/keyBy.test.ts
+++ b/functionsUnittests/objectFunctions/keyBy.test.ts
@@ -2,7 +2,7 @@ import { keyBy } from '../../objectFunctions/keyBy';
 
 describe('keyBy', () => {
   // Test case 1: Group by a string key
-  it('Test case 1: should group by a string key', () => {
+  it('1. should group by a string key', () => {
     const array = [
       { id: 'a', name: 'apple' },
       { id: 'b', name: 'banana' },
@@ -18,7 +18,7 @@ describe('keyBy', () => {
   });
 
   // Test case 2: Group by a number key
-  it('Test case 2: should group by a number key', () => {
+  it('2. should group by a number key', () => {
     const array = [
       { id: 1, name: 'apple' },
       { id: 2, name: 'banana' },
@@ -34,7 +34,7 @@ describe('keyBy', () => {
   });
 
   // Test case 3: Group by a boolean key
-  it('Test case 3: should group by a boolean key', () => {
+  it('3. should group by a boolean key', () => {
     const array = [
       { isFruit: true, name: 'apple' },
       { isFruit: true, name: 'banana' },
@@ -49,7 +49,7 @@ describe('keyBy', () => {
   });
 
   // Test case 4: Handle empty array
-  it('Test case 4: should return an empty object for an empty array', () => {
+  it('4. should return an empty object for an empty array', () => {
     const array: Array<Record<string, unknown>> = [];
     const result = keyBy(array, 'id');
     const expected = {};
@@ -57,7 +57,7 @@ describe('keyBy', () => {
   });
 
   // Test case 5: Handle array with no matching key
-  it('Test case 5: should return an empty object if key does not exist', () => {
+  it('5. should return an empty object if key does not exist', () => {
     const array = [
       { id: 'a', name: 'apple' },
       { id: 'b', name: 'banana' },
@@ -69,35 +69,35 @@ describe('keyBy', () => {
   });
 
   // Test case 6: Handle non-array input (number)
-  it('Test case 6: should throw a TypeError if input is a number', () => {
+  it('6. should throw a TypeError if input is a number', () => {
     expect(() =>
       keyBy(42 as unknown as Record<string, unknown>[], 'id'),
     ).toThrow(TypeError);
   });
 
   // Test case 7: Handle non-array input (string)
-  it('Test case 7: should throw a TypeError if input is a string', () => {
+  it('7. should throw a TypeError if input is a string', () => {
     expect(() =>
       keyBy('string' as unknown as Record<string, unknown>[], 'id'),
     ).toThrow(TypeError);
   });
 
   // Test case 8: Handle non-array input (boolean)
-  it('Test case 8: should throw a TypeError if input is a boolean', () => {
+  it('8. should throw a TypeError if input is a boolean', () => {
     expect(() =>
       keyBy(true as unknown as Record<string, unknown>[], 'id'),
     ).toThrow(TypeError);
   });
 
   // Test case 9: Handle null input
-  it('Test case 9: should throw a TypeError if input is null', () => {
+  it('9. should throw a TypeError if input is null', () => {
     expect(() =>
       keyBy(null as unknown as Record<string, unknown>[], 'id'),
     ).toThrow(TypeError);
   });
 
   // Test case 10: Handle undefined input
-  it('Test case 10: should throw a TypeError if input is undefined', () => {
+  it('10. should throw a TypeError if input is undefined', () => {
     expect(() =>
       keyBy(undefined as unknown as Record<string, unknown>[], 'id'),
     ).toThrow(TypeError);

--- a/functionsUnittests/objectFunctions/omitBy.test.ts
+++ b/functionsUnittests/objectFunctions/omitBy.test.ts
@@ -2,7 +2,7 @@ import { omitBy } from '../../objectFunctions/omitBy';
 
 describe('omitBy', () => {
   // Test case 1: Omit properties based on value
-  it('Test case 1: should omit properties based on value', () => {
+  it('1. should omit properties based on value', () => {
     const obj = { a: 1, b: 2, c: 3 };
     const result = omitBy(obj, (value) => (value as number) > 1);
     const expected = { a: 1 };
@@ -10,7 +10,7 @@ describe('omitBy', () => {
   });
 
   // Test case 2: Omit properties based on key
-  it('Test case 2: should omit properties based on key', () => {
+  it('2. should omit properties based on key', () => {
     const obj = { a: 1, b: 2, c: 3 };
     const result = omitBy(obj, (value, key) => key === 'b');
     const expected = { a: 1, c: 3 };
@@ -18,7 +18,7 @@ describe('omitBy', () => {
   });
 
   // Test case 3: Omit properties with different data types
-  it('Test case 3: should omit properties with different data types', () => {
+  it('3. should omit properties with different data types', () => {
     const obj = { a: 1, b: 'string', c: true, d: null };
     const result = omitBy(obj, (value) => typeof value === 'string');
     const expected = { a: 1, c: true, d: null };
@@ -26,7 +26,7 @@ describe('omitBy', () => {
   });
 
   // Test case 4: Omit no properties if predicate always returns false
-  it('Test case 4: should omit no properties if predicate always returns false', () => {
+  it('4. should omit no properties if predicate always returns false', () => {
     const obj = { a: 1, b: 2, c: 3 };
     const result = omitBy(obj, () => false);
     const expected = { a: 1, b: 2, c: 3 };
@@ -34,7 +34,7 @@ describe('omitBy', () => {
   });
 
   // Test case 5: Omit all properties if predicate always returns true
-  it('Test case 5: should omit all properties if predicate always returns true', () => {
+  it('5. should omit all properties if predicate always returns true', () => {
     const obj = { a: 1, b: 2, c: 3 };
     const result = omitBy(obj, () => true);
     const expected = {};
@@ -42,7 +42,7 @@ describe('omitBy', () => {
   });
 
   // Test case 6: Omit properties from an object with nested objects
-  it('Test case 6: should omit properties from an object with nested objects', () => {
+  it('6. should omit properties from an object with nested objects', () => {
     const obj = { a: 1, b: { c: 2, d: 3 }, e: 4 };
     const result = omitBy(obj, (value) => typeof value === 'object');
     const expected = { a: 1, e: 4 };
@@ -50,7 +50,7 @@ describe('omitBy', () => {
   });
 
   // Test case 7: Omit properties from an object with Date objects
-  it('Test case 7: should omit properties from an object with Date objects', () => {
+  it('7. should omit properties from an object with Date objects', () => {
     const date = new Date();
     const obj = { a: 1, b: date, c: 3 };
     const result = omitBy(obj, (value) => value instanceof Date);
@@ -59,7 +59,7 @@ describe('omitBy', () => {
   });
 
   // Test case 8: Handle non-object input (number)
-  it('Test case 8: should throw a TypeError if input is a number', () => {
+  it('8. should throw a TypeError if input is a number', () => {
     expect(() =>
       omitBy(42 as unknown as Record<string, unknown>, (value) =>
         Boolean(value),
@@ -68,7 +68,7 @@ describe('omitBy', () => {
   });
 
   // Test case 9: Handle non-object input (string)
-  it('Test case 9: should throw a TypeError if input is a string', () => {
+  it('9. should throw a TypeError if input is a string', () => {
     expect(() =>
       omitBy('string' as unknown as Record<string, unknown>, (value) =>
         Boolean(value),
@@ -77,7 +77,7 @@ describe('omitBy', () => {
   });
 
   // Test case 10: Handle non-object input (boolean)
-  it('Test case 10: should throw a TypeError if input is a boolean', () => {
+  it('10. should throw a TypeError if input is a boolean', () => {
     expect(() =>
       omitBy(true as unknown as Record<string, unknown>, (value) =>
         Boolean(value),
@@ -86,7 +86,7 @@ describe('omitBy', () => {
   });
 
   // Test case 11: Handle null input
-  it('Test case 11: should throw a TypeError if input is null', () => {
+  it('11. should throw a TypeError if input is null', () => {
     expect(() =>
       omitBy(null as unknown as Record<string, unknown>, (value) =>
         Boolean(value),
@@ -95,7 +95,7 @@ describe('omitBy', () => {
   });
 
   // Test case 12: Handle undefined input
-  it('Test case 12: should throw a TypeError if input is undefined', () => {
+  it('12. should throw a TypeError if input is undefined', () => {
     expect(() =>
       omitBy(undefined as unknown as Record<string, unknown>, (value) =>
         Boolean(value),

--- a/functionsUnittests/objectFunctions/pickBy.test.ts
+++ b/functionsUnittests/objectFunctions/pickBy.test.ts
@@ -2,7 +2,7 @@ import { pickBy } from '../../objectFunctions/pickBy';
 
 describe('pickBy', () => {
   // Test case 1: Pick properties based on value
-  it('Test case 1: should pick properties based on value', () => {
+  it('1. should pick properties based on value', () => {
     const obj = { a: 1, b: 2, c: 3 };
     const result = pickBy(obj, (value) => (value as number) > 1);
     const expected = { b: 2, c: 3 };
@@ -10,7 +10,7 @@ describe('pickBy', () => {
   });
 
   // Test case 2: Pick properties based on key
-  it('Test case 2: should pick properties based on key', () => {
+  it('2. should pick properties based on key', () => {
     const obj = { a: 1, b: 2, c: 3 };
     const result = pickBy(obj, (value, key) => key === 'b');
     const expected = { b: 2 };
@@ -18,7 +18,7 @@ describe('pickBy', () => {
   });
 
   // Test case 3: Pick properties with different data types
-  it('Test case 3: should pick properties with different data types', () => {
+  it('3. should pick properties with different data types', () => {
     const obj = { a: 1, b: 'string', c: true, d: null };
     const result = pickBy(obj, (value) => typeof value === 'string');
     const expected = { b: 'string' };
@@ -26,7 +26,7 @@ describe('pickBy', () => {
   });
 
   // Test case 4: Pick no properties if predicate always returns false
-  it('Test case 4: should pick no properties if predicate always returns false', () => {
+  it('4. should pick no properties if predicate always returns false', () => {
     const obj = { a: 1, b: 2, c: 3 };
     const result = pickBy(obj, () => false);
     const expected = {};
@@ -34,7 +34,7 @@ describe('pickBy', () => {
   });
 
   // Test case 5: Pick all properties if predicate always returns true
-  it('Test case 5: should pick all properties if predicate always returns true', () => {
+  it('5. should pick all properties if predicate always returns true', () => {
     const obj = { a: 1, b: 2, c: 3 };
     const result = pickBy(obj, () => true);
     const expected = { a: 1, b: 2, c: 3 };
@@ -42,7 +42,7 @@ describe('pickBy', () => {
   });
 
   // Test case 6: Pick properties from an object with nested objects
-  it('Test case 6: should pick properties from an object with nested objects', () => {
+  it('6. should pick properties from an object with nested objects', () => {
     const obj = { a: 1, b: { c: 2, d: 3 }, e: 4 };
     const result = pickBy(obj, (value) => typeof value === 'object');
     const expected = { b: { c: 2, d: 3 } };
@@ -50,7 +50,7 @@ describe('pickBy', () => {
   });
 
   // Test case 7: Pick properties from an object with Date objects
-  it('Test case 7: should pick properties from an object with Date objects', () => {
+  it('7. should pick properties from an object with Date objects', () => {
     const date = new Date();
     const obj = { a: 1, b: date, c: 3 };
     const result = pickBy(obj, (value) => value instanceof Date);
@@ -59,7 +59,7 @@ describe('pickBy', () => {
   });
 
   // Test case 8: Handle non-object input (number)
-  it('Test case 8: should throw a TypeError if input is a number', () => {
+  it('8. should throw a TypeError if input is a number', () => {
     expect(() =>
       pickBy(42 as unknown as Record<string, unknown>, (value) =>
         Boolean(value),
@@ -68,7 +68,7 @@ describe('pickBy', () => {
   });
 
   // Test case 9: Handle non-object input (string)
-  it('Test case 9: should throw a TypeError if input is a string', () => {
+  it('9. should throw a TypeError if input is a string', () => {
     expect(() =>
       pickBy('string' as unknown as Record<string, unknown>, (value) =>
         Boolean(value),
@@ -77,7 +77,7 @@ describe('pickBy', () => {
   });
 
   // Test case 10: Handle non-object input (boolean)
-  it('Test case 10: should throw a TypeError if input is a boolean', () => {
+  it('10. should throw a TypeError if input is a boolean', () => {
     expect(() =>
       pickBy(true as unknown as Record<string, unknown>, (value) =>
         Boolean(value),
@@ -86,7 +86,7 @@ describe('pickBy', () => {
   });
 
   // Test case 11: Handle null input
-  it('Test case 11: should throw a TypeError if input is null', () => {
+  it('11. should throw a TypeError if input is null', () => {
     expect(() =>
       pickBy(null as unknown as Record<string, unknown>, (value) =>
         Boolean(value),
@@ -95,7 +95,7 @@ describe('pickBy', () => {
   });
 
   // Test case 12: Handle undefined input
-  it('Test case 12: should throw a TypeError if input is undefined', () => {
+  it('12. should throw a TypeError if input is undefined', () => {
     expect(() =>
       pickBy(undefined as unknown as Record<string, unknown>, (value) =>
         Boolean(value),

--- a/functionsUnittests/objectFunctions/safeGet.test.ts
+++ b/functionsUnittests/objectFunctions/safeGet.test.ts
@@ -2,7 +2,7 @@ import { safeGet } from '../../objectFunctions/safeGet';
 
 describe('safeGet', () => {
   // Test case 1: Retrieve a nested value
-  it('Test case 1: should retrieve a nested value', () => {
+  it('1. should retrieve a nested value', () => {
     const obj = { a: { b: { c: 42 } } };
     const result = safeGet(obj, 'a.b.c');
     const expected = 42;
@@ -10,7 +10,7 @@ describe('safeGet', () => {
   });
 
   // Test case 2: Return default value if path does not exist
-  it('Test case 2: should return default value if path does not exist', () => {
+  it('2. should return default value if path does not exist', () => {
     const obj = { a: { b: { c: 42 } } };
     const result = safeGet(obj, 'a.b.d', 'default');
     const expected = 'default';
@@ -18,7 +18,7 @@ describe('safeGet', () => {
   });
 
   // Test case 3: Handle empty path
-  it('Test case 3: should return the object itself if path is empty', () => {
+  it('3. should return the object itself if path is empty', () => {
     const obj = { a: { b: { c: 42 } } };
     const result = safeGet(obj, '');
     const expected = obj;
@@ -26,7 +26,7 @@ describe('safeGet', () => {
   });
 
   // Test case 4: Handle array path
-  it('Test case 4: should retrieve a value from an array path', () => {
+  it('4. should retrieve a value from an array path', () => {
     const obj = { a: [{ b: 42 }] };
     const result = safeGet(obj, 'a.0.b');
     const expected = 42;
@@ -34,7 +34,7 @@ describe('safeGet', () => {
   });
 
   // Test case 5: Handle path with special characters
-  it('Test case 5: should retrieve a value from a path with special characters', () => {
+  it('5. should retrieve a value from a path with special characters', () => {
     const obj = { 'a-b': { 'c.d': 42 } };
     const result = safeGet(obj, 'a-b.c.d');
     const expected = 42;
@@ -42,7 +42,7 @@ describe('safeGet', () => {
   });
 
   // Test case 6: Handle path with spaces
-  it('Test case 6: should retrieve a value from a path with spaces', () => {
+  it('6. should retrieve a value from a path with spaces', () => {
     const obj = { 'a b': { 'c d': 42 } };
     const result = safeGet(obj, 'a b.c d');
     const expected = 42;
@@ -50,7 +50,7 @@ describe('safeGet', () => {
   });
 
   // Test case 7: Handle path with empty segments
-  it('Test case 7: should return default value for path with empty segments', () => {
+  it('7. should return default value for path with empty segments', () => {
     const obj = { a: { b: { c: 42 } } };
     const result = safeGet(obj, 'a..b.c', 'default');
     const expected = 'default';
@@ -58,7 +58,7 @@ describe('safeGet', () => {
   });
 
   // Test case 8: Handle path with leading and trailing dots
-  it('Test case 8: should retrieve a value from a path with leading and trailing dots', () => {
+  it('8. should retrieve a value from a path with leading and trailing dots', () => {
     const obj = { a: { b: { c: 42 } } };
     const result = safeGet(obj, '.a.b.c.', 'default');
     const expected = 42;
@@ -66,7 +66,7 @@ describe('safeGet', () => {
   });
 
   // Test case 9: Handle path with numeric keys
-  it('Test case 9: should retrieve a value from a path with numeric keys', () => {
+  it('9. should retrieve a value from a path with numeric keys', () => {
     const obj = { a: { 1: { b: 42 } } };
     const result = safeGet(obj, 'a.1.b');
     const expected = 42;
@@ -74,7 +74,7 @@ describe('safeGet', () => {
   });
 
   // Test case 10: Handle path with mixed types
-  it('Test case 10: should retrieve a value from a path with mixed types', () => {
+  it('10. should retrieve a value from a path with mixed types', () => {
     const obj = { a: [{ b: { c: 42 } }] };
     const result = safeGet(obj, 'a.0.b.c');
     const expected = 42;
@@ -82,35 +82,35 @@ describe('safeGet', () => {
   });
 
   // Test case 11: Handle non-object input (number)
-  it('Test case 11: should throw a TypeError if input is a number', () => {
+  it('11. should throw a TypeError if input is a number', () => {
     expect(() =>
       safeGet(42 as unknown as Record<string, unknown>, 'a.b.c'),
     ).toThrow(TypeError);
   });
 
   // Test case 12: Handle non-object input (string)
-  it('Test case 12: should throw a TypeError if input is a string', () => {
+  it('12. should throw a TypeError if input is a string', () => {
     expect(() =>
       safeGet('string' as unknown as Record<string, unknown>, 'a.b.c'),
     ).toThrow(TypeError);
   });
 
   // Test case 13: Handle non-object input (boolean)
-  it('Test case 13: should throw a TypeError if input is a boolean', () => {
+  it('13. should throw a TypeError if input is a boolean', () => {
     expect(() =>
       safeGet(true as unknown as Record<string, unknown>, 'a.b.c'),
     ).toThrow(TypeError);
   });
 
   // Test case 14: Handle null input
-  it('Test case 14: should throw a TypeError if input is null', () => {
+  it('14. should throw a TypeError if input is null', () => {
     expect(() =>
       safeGet(null as unknown as Record<string, unknown>, 'a.b.c'),
     ).toThrow(TypeError);
   });
 
   // Test case 15: Handle undefined input
-  it('Test case 15: should throw a TypeError if input is undefined', () => {
+  it('15. should throw a TypeError if input is undefined', () => {
     expect(() =>
       safeGet(undefined as unknown as Record<string, unknown>, 'a.b.c'),
     ).toThrow(TypeError);

--- a/functionsUnittests/objectFunctions/safeSet.test.ts
+++ b/functionsUnittests/objectFunctions/safeSet.test.ts
@@ -2,7 +2,7 @@ import { safeSet } from '../../objectFunctions/safeSet';
 
 describe('safeSet', () => {
   // Test case 1: Set a nested value
-  it('Test case 1: should set a nested value', () => {
+  it('1. should set a nested value', () => {
     const obj = { a: { b: { c: 42 } } };
     safeSet(obj, 'a.b.c', 100);
     const expected = { a: { b: { c: 100 } } };
@@ -10,7 +10,7 @@ describe('safeSet', () => {
   });
 
   // Test case 2: Create nested objects if path does not exist
-  it('Test case 2: should create nested objects if path does not exist', () => {
+  it('2. should create nested objects if path does not exist', () => {
     const obj = { a: { b: { c: 42 } } };
     safeSet(obj, 'a.b.d.e', 100);
     const expected = { a: { b: { c: 42, d: { e: 100 } } } };
@@ -18,7 +18,7 @@ describe('safeSet', () => {
   });
 
   // Test case 3: Handle empty path
-  it('Test case 3: should not modify the object if path is empty', () => {
+  it('3. should not modify the object if path is empty', () => {
     const obj = { a: { b: { c: 42 } } };
     safeSet(obj, '', 100);
     const expected = { a: { b: { c: 42 } } };
@@ -26,7 +26,7 @@ describe('safeSet', () => {
   });
 
   // Test case 4: Handle path with special characters
-  it('Test case 4: should set a value for a path with special characters', () => {
+  it('4. should set a value for a path with special characters', () => {
     const obj = { 'a-b': { 'c.d': 42 } };
     safeSet(obj, 'a-b.c.d', 100);
     const expected = { 'a-b': { 'c.d': 100 } };
@@ -34,7 +34,7 @@ describe('safeSet', () => {
   });
 
   // Test case 5: Handle path with spaces
-  it('Test case 5: should set a value for a path with spaces', () => {
+  it('5. should set a value for a path with spaces', () => {
     const obj = { 'a b': { 'c d': 42 } };
     safeSet(obj, 'a b.c d', 100);
     const expected = { 'a b': { 'c d': 100 } };
@@ -42,7 +42,7 @@ describe('safeSet', () => {
   });
 
   // Test case 6: Handle path with numeric keys
-  it('Test case 6: should set a value for a path with numeric keys', () => {
+  it('6. should set a value for a path with numeric keys', () => {
     const obj = { a: { 1: { b: 42 } } };
     safeSet(obj, 'a.1.b', 100);
     const expected = { a: { 1: { b: 100 } } };
@@ -50,7 +50,7 @@ describe('safeSet', () => {
   });
 
   // Test case 7: Handle path with mixed types
-  it('Test case 7: should set a value for a path with mixed types', () => {
+  it('7. should set a value for a path with mixed types', () => {
     const obj = { a: [{ b: { c: 42 } }] };
     safeSet(obj, 'a.0.b.c', 100);
     const expected = { a: [{ b: { c: 100 } }] };
@@ -58,27 +58,27 @@ describe('safeSet', () => {
   });
 
   // Test case 8: Handle non-object input (number)
-  it('Test case 8: should throw a TypeError if input is a number', () => {
+  it('8. should throw a TypeError if input is a number', () => {
     expect(() => safeSet(42 as any, 'a.b.c', 100)).toThrow(TypeError);
   });
 
   // Test case 9: Handle non-object input (string)
-  it('Test case 9: should throw a TypeError if input is a string', () => {
+  it('9. should throw a TypeError if input is a string', () => {
     expect(() => safeSet('string' as any, 'a.b.c', 100)).toThrow(TypeError);
   });
 
   // Test case 10: Handle non-object input (boolean)
-  it('Test case 10: should throw a TypeError if input is a boolean', () => {
+  it('10. should throw a TypeError if input is a boolean', () => {
     expect(() => safeSet(true as any, 'a.b.c', 100)).toThrow(TypeError);
   });
 
   // Test case 11: Handle null input
-  it('Test case 11: should throw a TypeError if input is null', () => {
+  it('11. should throw a TypeError if input is null', () => {
     expect(() => safeSet(null as any, 'a.b.c', 100)).toThrow(TypeError);
   });
 
   // Test case 12: Handle undefined input
-  it('Test case 12: should throw a TypeError if input is undefined', () => {
+  it('12. should throw a TypeError if input is undefined', () => {
     expect(() => safeSet(undefined as any, 'a.b.c', 100)).toThrow(TypeError);
   });
 });


### PR DESCRIPTION
## Summary
- standardize object function unit tests to use `1.`, `2.`, … numbering in `it` descriptions
- ensure numbering runs sequentially across object test files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898993269a883259b26c422c3b54f11