### PR TITLE
refactor: promote test helpers out of describe blocks

### DIFF
--- a/functionsUnittests/arrayFunctionsUnittests/shuffleArray.test.ts
+++ b/functionsUnittests/arrayFunctionsUnittests/shuffleArray.test.ts
@@ -1,14 +1,15 @@
 import { shuffleArray } from '../../arrayFunctions/shuffleArray';
 
+// Helper function to check if two arrays are equal
+const arraysEqual = <T>(a: T[], b: T[]): boolean => {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+};
+
 describe('shuffleArray', () => {
-  // Helper function to check if two arrays are equal
-  const arraysEqual = <T>(a: T[], b: T[]): boolean => {
-    if (a.length !== b.length) return false;
-    for (let i = 0; i < a.length; i++) {
-      if (a[i] !== b[i]) return false;
-    }
-    return true;
-  };
 
   // Test case 1: Shuffling an array of numbers
   test('1. should shuffle an array of numbers', () => {

--- a/functionsUnittests/objectFunctions/deepCloneWith.test.ts
+++ b/functionsUnittests/objectFunctions/deepCloneWith.test.ts
@@ -1,7 +1,8 @@
 import { deepCloneWith } from '../../objectFunctions/deepCloneWith';
 
+const cloneFn = (value: unknown) => value;
+
 describe('deepCloneWith', () => {
-  const cloneFn = (value: unknown) => value;
 
   // Test case 1: Deep clone a simple object
   it('1. should deep clone a simple object', () => {

--- a/functionsUnittests/utilityFunctions/bytesToSize.test.ts
+++ b/functionsUnittests/utilityFunctions/bytesToSize.test.ts
@@ -1,15 +1,15 @@
 import { bytesToSize } from '../../utilityFunctions/bytesToSize';
 
-describe('bytesToSize', () => {
-  const cases: [number, string][] = [
-    [0, '0 Bytes'],
-    [512, '512.00 Bytes'],
-    [1023, '1023.00 Bytes'],
-    [1024, '1.00 KB'],
-    [1048576, '1.00 MB'],
-    [1073741824, '1.00 GB'],
-  ];
+const cases: [number, string][] = [
+  [0, '0 Bytes'],
+  [512, '512.00 Bytes'],
+  [1023, '1023.00 Bytes'],
+  [1024, '1.00 KB'],
+  [1048576, '1.00 MB'],
+  [1073741824, '1.00 GB'],
+];
 
+describe('bytesToSize', () => {
   test.each(cases)('%#. converts %i bytes', (input, expected) => {
     expect(bytesToSize(input)).toBe(expected);
   });

--- a/functionsUnittests/utilityFunctions/rgbToHex.test.ts
+++ b/functionsUnittests/utilityFunctions/rgbToHex.test.ts
@@ -1,16 +1,16 @@
 import { rgbToHex } from '../../utilityFunctions/rgbToHex';
 
-describe('rgbToHex', () => {
-  const cases: [{ r: number; g: number; b: number }, string][] = [
-    [{ r: 255, g: 87, b: 51 }, '#ff5733'],
-    [{ r: 0, g: 0, b: 0 }, '#000000'],
-    [{ r: 1, g: 2, b: 3 }, '#010203'],
-    [{ r: 16, g: 32, b: 48 }, '#102030'],
-    [{ r: 255, g: 255, b: 255 }, '#ffffff'],
-    [{ r: -1, g: -20, b: -300 }, '#000000'],
-    [{ r: 256, g: 300, b: 999 }, '#ffffff'],
-  ];
+const cases: [{ r: number; g: number; b: number }, string][] = [
+  [{ r: 255, g: 87, b: 51 }, '#ff5733'],
+  [{ r: 0, g: 0, b: 0 }, '#000000'],
+  [{ r: 1, g: 2, b: 3 }, '#010203'],
+  [{ r: 16, g: 32, b: 48 }, '#102030'],
+  [{ r: 255, g: 255, b: 255 }, '#ffffff'],
+  [{ r: -1, g: -20, b: -300 }, '#000000'],
+  [{ r: 256, g: 300, b: 999 }, '#ffffff'],
+];
 
+describe('rgbToHex', () => {
   test.each(cases)('%#. converts %o to %s', (input, expected) => {
     expect(rgbToHex(input)).toBe(expected);
   });


### PR DESCRIPTION
## Summary
- move array equality helper above `shuffleArray` tests
- lift test data arrays in `rgbToHex` and `bytesToSize` specs
- hoist reusable clone function in `deepCloneWith` tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898993548208325aba0813e87331bcb