### PR TITLE
Handle zero-argument zipMultiple

### DIFF
--- a/arrayFunctions/zipMultiple.ts
+++ b/arrayFunctions/zipMultiple.ts
@@ -41,6 +41,10 @@ type ZippedTuple<T extends unknown[][]> = { [K in keyof T]: T[K][number] };
 export function zipMultiple<T extends unknown[][]>(
   ...arrays: T
 ): ZippedTuple<T>[] {
+  if (arrays.length === 0) {
+    return [];
+  }
+
   const minLength = Math.min(...arrays.map((arr) => arr.length));
   const result: ZippedTuple<T>[] = [];
   for (let i = 0; i < minLength; i++) {

--- a/functionsUnittests/arrayFunctionsUnittests/zipMultiple.test.ts
+++ b/functionsUnittests/arrayFunctionsUnittests/zipMultiple.test.ts
@@ -285,4 +285,9 @@ describe('zipMultiple', () => {
       [undefined, undefined, undefined],
     ]);
   });
+
+  test('21. should return an empty array when called without input arrays', () => {
+    const result = zipMultiple();
+    expect(result).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- guard `zipMultiple` against zero input arrays before computing the minimum length
- add a unit test ensuring `zipMultiple()` returns an empty array when called without arguments

## Testing
- npm run test:local -- zipMultiple

------
https://chatgpt.com/codex/tasks/task_e_68cfe56352c08325a5da75d7fcd1ad78