### PR TITLE
Fix query parsing for values containing equals

### DIFF
--- a/functionsUnittests/utilityFunctions/parseQueryString.test.ts
+++ b/functionsUnittests/utilityFunctions/parseQueryString.test.ts
@@ -86,4 +86,12 @@ describe('parseQueryString', () => {
     const expected = { name: 'John' };
     expect(result).toEqual(expected);
   });
+
+  // Test case 12: Preserve equals signs within parameter values
+  it('12. should preserve equals signs within parameter values', () => {
+    const queryString = '?token=abc=def=ghi&signature=XYZ%3D%3D';
+    const result = parseQueryString(queryString);
+    const expected = { token: 'abc=def=ghi', signature: 'XYZ==' };
+    expect(result).toEqual(expected);
+  });
 });

--- a/utilityFunctions/parseQueryString.ts
+++ b/utilityFunctions/parseQueryString.ts
@@ -25,11 +25,16 @@ export function parseQueryString(queryString: string): Record<string, string> {
     .filter(Boolean)
     .reduce(
       (acc, queryParam) => {
-        const [key, value] = queryParam.split('=');
+        const [key, ...rest] = queryParam.split('=');
+
         if (!key) {
           return acc;
         }
-        acc[decodeURIComponent(key)] = decodeURIComponent(value || '');
+
+        const value = rest.join('=');
+
+        acc[decodeURIComponent(key)] = decodeURIComponent(value);
+
         return acc;
       },
       {} as Record<string, string>,


### PR DESCRIPTION
## Summary
- ensure `parseQueryString` only splits parameters on the first equals sign so values are preserved
- decode the full remainder of the parameter value after rejoining
- add a unit test covering parameters that contain additional equals signs

## Testing
- npm run test:local -- parseQueryString

------
https://chatgpt.com/codex/tasks/task_e_68cfe67a76808325b795b421e46e4d21