### PR TITLE
Handle '=' characters in query values

### DIFF
--- a/functionsUnittests/objectFunctions/queryStringToObject.test.ts
+++ b/functionsUnittests/objectFunctions/queryStringToObject.test.ts
@@ -78,4 +78,16 @@ describe('queryStringToObject', () => {
       TypeError,
     );
   });
+
+  it('10. should preserve additional equals signs in parameter values', () => {
+    const queryString = 'token=a=b=c&empty=&flag';
+    const result = queryStringToObject(queryString);
+    expect(result).toEqual({ token: 'a=b=c', empty: '', flag: '' });
+  });
+
+  it('11. should decode encoded equals signs inside parameter values', () => {
+    const queryString = 'note=foo%3Dbar%3Dbaz&data=hello%3Dworld';
+    const result = queryStringToObject(queryString);
+    expect(result).toEqual({ note: 'foo=bar=baz', data: 'hello=world' });
+  });
 });

--- a/functionsUnittests/objectFunctions/queryStringToObject.test.ts
+++ b/functionsUnittests/objectFunctions/queryStringToObject.test.ts
@@ -44,50 +44,50 @@ describe('queryStringToObject', () => {
     expect(result).toEqual(expected);
   });
 
+  it('5. should preserve additional equals signs in parameter values', () => {
+    const queryString = 'token=a=b=c&empty=&flag';
+    const result = queryStringToObject(queryString);
+    expect(result).toEqual({ token: 'a=b=c', empty: '', flag: '' });
+  });
+
+  it('6. should decode encoded equals signs inside parameter values', () => {
+    const queryString = 'note=foo%3Dbar%3Dbaz&data=hello%3Dworld';
+    const result = queryStringToObject(queryString);
+    expect(result).toEqual({ note: 'foo=bar=baz', data: 'hello=world' });
+  });
+
   // Test case 5: Handle non-string input (number)
-  it('5. should throw a TypeError if input is a number', () => {
+  it('7. should throw a TypeError if input is a number', () => {
     expect(() => queryStringToObject(42 as unknown as string)).toThrow(
       TypeError,
     );
   });
 
   // Test case 6: Handle non-string input (object)
-  it('6. should throw a TypeError if input is an object', () => {
+  it('8. should throw a TypeError if input is an object', () => {
     expect(() => queryStringToObject({} as unknown as string)).toThrow(
       TypeError,
     );
   });
 
   // Test case 7: Handle non-string input (boolean)
-  it('7. should throw a TypeError if input is a boolean', () => {
+  it('9. should throw a TypeError if input is a boolean', () => {
     expect(() => queryStringToObject(true as unknown as string)).toThrow(
       TypeError,
     );
   });
 
   // Test case 8: Handle non-string input (null)
-  it('8. should throw a TypeError if input is null', () => {
+  it('10. should throw a TypeError if input is null', () => {
     expect(() => queryStringToObject(null as unknown as string)).toThrow(
       TypeError,
     );
   });
 
   // Test case 9: Handle non-string input (undefined)
-  it('9. should throw a TypeError if input is undefined', () => {
+  it('11. should throw a TypeError if input is undefined', () => {
     expect(() => queryStringToObject(undefined as unknown as string)).toThrow(
       TypeError,
     );
-  });
-
-  it('10. should preserve additional equals signs in parameter values', () => {
-    const queryString = 'token=a=b=c&empty=&flag';
-    const result = queryStringToObject(queryString);
-    expect(result).toEqual({ token: 'a=b=c', empty: '', flag: '' });
-  });
-
-  it('11. should decode encoded equals signs inside parameter values', () => {
-    const queryString = 'note=foo%3Dbar%3Dbaz&data=hello%3Dworld';
-    const result = queryStringToObject(queryString);
-    expect(result).toEqual({ note: 'foo=bar=baz', data: 'hello=world' });
   });
 });

--- a/objectFunctions/queryStringToObject.ts
+++ b/objectFunctions/queryStringToObject.ts
@@ -31,10 +31,11 @@ export function queryStringToObject(
   return str
     .split('&')
     .filter(Boolean)
-    .map((param) => param.split('='))
     .reduce(
-      (acc, [key, value]) => {
+      (acc, param) => {
+        const [key, ...rest] = param.split('=');
         if (key) {
+          const value = rest.length > 0 ? rest.join('=') : undefined;
           acc[decodeURIComponent(key)] = decodeURIComponent(value ?? '');
         }
         return acc;


### PR DESCRIPTION
## Summary
- update `queryStringToObject` to reconstruct parameter values from the substring after the first equals sign
- ensure decoded values still behave like empty parameters when no value is provided
- add test coverage for query parameters whose values contain additional equals signs

## Testing
- npm run test:local -- queryStringToObject


------
https://chatgpt.com/codex/tasks/task_e_68cfe67b8ea08325a197ce9ed1952ed4