### PR TITLE
Handle empty replacements in replaceMultiple

### DIFF
--- a/functionsUnittests/stringFunctions/replaceMultiple.test.ts
+++ b/functionsUnittests/stringFunctions/replaceMultiple.test.ts
@@ -168,4 +168,16 @@ describe('replaceMultiple', () => {
     const result: string = replaceMultiple(str, replacements);
     expect(result).toBe(expected);
   });
+
+  // Test case 16: Return the original string when replacements object is empty
+  it('16. should return the original string when replacements object is empty', () => {
+    const str: string = 'abc';
+
+    expect(replaceMultiple(str, {})).toBe(str);
+
+    const replacementsWithoutPrototype = Object.create(null) as {
+      [key: string]: string;
+    };
+    expect(replaceMultiple(str, replacementsWithoutPrototype)).toBe(str);
+  });
 });

--- a/stringFunctions/replaceMultiple.ts
+++ b/stringFunctions/replaceMultiple.ts
@@ -14,7 +14,13 @@ export function replaceMultiple(
   str: string,
   replacements: { [key: string]: string },
 ): string {
-  const escapedKeys = Object.keys(replacements).map(
+  const replacementKeys = Object.keys(replacements);
+
+  if (replacementKeys.length === 0) {
+    return str;
+  }
+
+  const escapedKeys = replacementKeys.map(
     (key) => key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), // Escape special regex characters
   );
 


### PR DESCRIPTION
## Summary
- ensure replaceMultiple returns the original string when the replacements map is empty
- add unit coverage for empty replacement maps, including objects without prototypes

## Testing
- npm run test:local -- replaceMultiple

------
https://chatgpt.com/codex/tasks/task_e_68d17fe7a3588325afeaf78ef72661b1