### PR TITLE
Fix throttle trailing execution timing

### DIFF
--- a/functionsUnittests/utilityFunctions/throttle.test.ts
+++ b/functionsUnittests/utilityFunctions/throttle.test.ts
@@ -69,4 +69,23 @@ describe('throttle', () => {
       done();
     }, 60);
   });
+
+  it('5. should throttle immediately after a trailing execution', (done) => {
+    const mockFn = jest.fn();
+    const throttled = throttle(mockFn, 30);
+
+    throttled();
+    throttled();
+
+    setTimeout(() => {
+      expect(mockFn).toHaveBeenCalledTimes(2);
+      throttled();
+      expect(mockFn).toHaveBeenCalledTimes(2);
+    }, 40);
+
+    setTimeout(() => {
+      expect(mockFn).toHaveBeenCalledTimes(3);
+      done();
+    }, 80);
+  });
 });

--- a/utilityFunctions/throttle.ts
+++ b/utilityFunctions/throttle.ts
@@ -31,6 +31,8 @@ export function throttle<Args extends unknown[]>(
       lastFunc = setTimeout(
         () => {
           func.apply(this, args);
+          lastRan = Date.now();
+          lastFunc = null;
         },
         limit - (Date.now() - lastRan),
       );


### PR DESCRIPTION
## Summary
- update the throttle utility so trailing executions update the last-run timestamp and clear the pending timeout
- add a regression unit test that verifies an invocation immediately after a trailing call remains throttled

## Testing
- npm run test:local -- functionsUnittests/utilityFunctions/throttle.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6afa54eb48325906b907b174a4427