### PR TITLE
Guard isDeepSubset recursion on non-object values

### DIFF
--- a/functionsUnittests/objectFunctions/isDeepSubset.test.ts
+++ b/functionsUnittests/objectFunctions/isDeepSubset.test.ts
@@ -137,23 +137,32 @@ describe('isDeepSubset', () => {
     expect(result).toBe(false);
   });
 
+  // Test case 18: Missing nested key should return false without throwing
+  it('18. should return false if nested key is missing in the object', () => {
+    const subset = { a: { b: 2 } } as Record<string, unknown>;
+    const obj = { a: 1 } as Record<string, unknown>;
+
+    expect(() => isDeepSubset(subset, obj)).not.toThrow();
+    expect(isDeepSubset(subset, obj)).toBe(false);
+  });
+
   // Error-handling test cases
-  // Test case 18: Handle non-object subset
-  it('18. should throw a TypeError if subset is not an object', () => {
+  // Test case 19: Handle non-object subset
+  it('19. should throw a TypeError if subset is not an object', () => {
     expect(() =>
       isDeepSubset(null as unknown as Record<string, unknown>, { a: 1 }),
     ).toThrow(TypeError);
   });
 
-  // Test case 19: Handle non-object obj
-  it('19. should throw a TypeError if obj is not an object', () => {
+  // Test case 20: Handle non-object obj
+  it('20. should throw a TypeError if obj is not an object', () => {
     expect(() =>
       isDeepSubset({ a: 1 }, null as unknown as Record<string, unknown>),
     ).toThrow(TypeError);
   });
 
-  // Test case 20: Handle both subset and obj as non-objects
-  it('20. should throw a TypeError if both subset and obj are not objects', () => {
+  // Test case 21: Handle both subset and obj as non-objects
+  it('21. should throw a TypeError if both subset and obj are not objects', () => {
     expect(() =>
       isDeepSubset(
         null as unknown as Record<string, unknown>,

--- a/objectFunctions/isDeepSubset.ts
+++ b/objectFunctions/isDeepSubset.ts
@@ -28,12 +28,22 @@ export function isDeepSubset<T extends Record<string, unknown>>(
     throw new TypeError('Object must be a non-null object');
   }
 
-  return Object.keys(subset).every((key) =>
-    typeof subset[key] === 'object' && subset[key] !== null
-      ? isDeepSubset(
-          subset[key] as Record<string, unknown>,
-          obj[key] as Record<string, unknown>,
-        )
-      : subset[key] === obj[key],
-  );
+  return Object.keys(subset).every((key) => {
+    const subsetValue = subset[key];
+
+    if (typeof subsetValue === 'object' && subsetValue !== null) {
+      const objValue = obj[key];
+
+      if (typeof objValue !== 'object' || objValue === null) {
+        return false;
+      }
+
+      return isDeepSubset(
+        subsetValue as Record<string, unknown>,
+        objValue as Record<string, unknown>,
+      );
+    }
+
+    return subsetValue === obj[key];
+  });
 }


### PR DESCRIPTION
## Summary
- ensure `isDeepSubset` only recurses when the target value is a non-null object
- return `false` when nested keys are missing instead of throwing
- expand unit coverage to assert the new behavior

## Testing
- npm test -- isDeepSubset

------
https://chatgpt.com/codex/tasks/task_e_68d6d1dcdab88325af6806e7eae15bbe