### PR TITLE
Handle stray colon groups in IPv6 validation

### DIFF
--- a/functionsUnittests/validationFunctionsUnittest/isValidIPv6.test.ts
+++ b/functionsUnittests/validationFunctionsUnittest/isValidIPv6.test.ts
@@ -23,6 +23,8 @@ describe('isValidIPv6', () => {
     ); // Too many groups
     expect(isValidIPv6('gggg::1')).toBe(false); // Invalid hex characters
     expect(isValidIPv6('2001:db8::12345')).toBe(false); // Group too long
+    expect(isValidIPv6('2001:db8::1:')).toBe(false); // Trailing colon creates empty group
+    expect(isValidIPv6(':2001:db8::1')).toBe(false); // Leading colon creates empty group
     expect(isValidIPv6('')).toBe(false); // Empty string
   });
 

--- a/validationFunctions/isValidIPv6.ts
+++ b/validationFunctions/isValidIPv6.ts
@@ -68,6 +68,10 @@ export function isValidIPv6(ip: string): boolean {
     if (groups.length !== 8) {
       return false;
     }
+
+    if (groups.some((group) => group === '')) {
+      return false;
+    }
   } else {
     // With compression
     const leftGroups = parts[0] === '' ? [] : parts[0].split(':');
@@ -75,6 +79,10 @@ export function isValidIPv6(ip: string): boolean {
 
     // Total groups should not exceed 8
     if (leftGroups.length + rightGroups.length >= 8) {
+      return false;
+    }
+
+    if (leftGroups.some((group) => group === '') || rightGroups.some((group) => group === '')) {
       return false;
     }
 


### PR DESCRIPTION
## Summary
- reject IPv6 addresses that include stray empty groups not caused by compression
- add unit tests covering trailing and leading colon IPv6 inputs

## Testing
- npm run test:local -- isValidIPv6

------
https://chatgpt.com/codex/tasks/task_e_68d6d1e40fb083258d3494acb898379d