### PR TITLE
Handle literal characters in countCharacterOccurrences

### DIFF
--- a/functionsUnittests/stringFunctions/countCharacterOccurrences.test.ts
+++ b/functionsUnittests/stringFunctions/countCharacterOccurrences.test.ts
@@ -40,6 +40,14 @@ describe('countCharacterOccurrences', () => {
     expect(result).toBe(expected);
   });
 
+  it('4a. should treat regular expression characters literally', () => {
+    const str: string = 'a.b';
+    const char: string = '.';
+    const expected: number = 1;
+    const result: number = countCharacterOccurrences(str, char);
+    expect(result).toBe(expected);
+  });
+
   // Test case 5: Count occurrences of a number
   it('5. should count occurrences of a number', () => {
     const str: string = 'hello 123 world 123';
@@ -107,6 +115,14 @@ describe('countCharacterOccurrences', () => {
   it('12. should return 0 when counting occurrences of a character in an empty string', () => {
     const str: string = '';
     const char: string = 'a';
+    const expected: number = 0;
+    const result: number = countCharacterOccurrences(str, char);
+    expect(result).toBe(expected);
+  });
+
+  it('12a. should return 0 when the character to count is empty', () => {
+    const str: string = 'hello world';
+    const char: string = '';
     const expected: number = 0;
     const result: number = countCharacterOccurrences(str, char);
     expect(result).toBe(expected);

--- a/stringFunctions/countCharacterOccurrences.ts
+++ b/stringFunctions/countCharacterOccurrences.ts
@@ -10,5 +10,11 @@
  *
  */
 export function countCharacterOccurrences(str: string, char: string): number {
-  return (str.match(new RegExp(char, 'g')) || []).length;
+  if (!char) {
+    return 0;
+  }
+
+  const escapedChar = char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  return (str.match(new RegExp(escapedChar, 'g')) || []).length;
 }


### PR DESCRIPTION
## Summary
- guard against empty character inputs and escape the search character before building the regex in `countCharacterOccurrences`
- extend `countCharacterOccurrences` unit tests with coverage for regex metacharacters and empty character inputs

## Testing
- npx jest --runTestsByPath functionsUnittests/stringFunctions/countCharacterOccurrences.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d949c1f2f48325bdae7155a1bfadf2