### PR TITLE
Escape regex metacharacters in countSubstring

### DIFF
--- a/functionsUnittests/stringFunctions/countSubstring.test.ts
+++ b/functionsUnittests/stringFunctions/countSubstring.test.ts
@@ -138,4 +138,13 @@ describe('countSubstring', () => {
     const result: number = countSubstring(str, substring);
     expect(result).toBe(expected);
   });
+
+  // Test case 16: Count occurrences of a substring containing regex metacharacters
+  it('16. should treat regex metacharacters in the substring literally', () => {
+    const str: string = 'values: a.*b, c+d, a.*b';
+    const substring: string = 'a.*b';
+    const expected: number = 2;
+    const result: number = countSubstring(str, substring);
+    expect(result).toBe(expected);
+  });
 });

--- a/stringFunctions/countSubstring.ts
+++ b/stringFunctions/countSubstring.ts
@@ -11,5 +11,6 @@
  */
 export function countSubstring(str: string, substring: string): number {
   if (substring.length === 0) return 0;
-  return (str.match(new RegExp(substring, 'g')) || []).length;
+  const escapedSubstring = substring.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return (str.match(new RegExp(escapedSubstring, 'g')) || []).length;
 }


### PR DESCRIPTION
## Summary
- escape metacharacters in `countSubstring` before creating a regular expression
- add a regression test to ensure substrings containing regex metacharacters are matched literally

## Testing
- npm test -- countSubstring

------
https://chatgpt.com/codex/tasks/task_e_68d949c4ec748325948d59f08eff8e7b