### PR TITLE
Reorder unit tests to group error cases

### DIFF
--- a/functionsUnittests/arrayFunctionsUnittests/chunkArray.test.ts
+++ b/functionsUnittests/arrayFunctionsUnittests/chunkArray.test.ts
@@ -26,34 +26,24 @@ describe('chunkArray', () => {
     expect(chunkArray([1, 2, 3], 3)).toEqual([[1, 2, 3]]);
   });
 
-  // Test case 6: Chunk size of 0 (invalid case)
-  it('6. should handle chunk size of 0', () => {
-    expect(() => chunkArray([1, 2, 3], 0)).toThrow();
-  });
-
-  // Test case 7: Negative chunk size (invalid case)
-  it('7. should handle negative chunk size', () => {
-    expect(() => chunkArray([1, 2, 3], -1)).toThrow();
-  });
-
-  // Test case 8: Non-integer chunk size
-  it('8. should handle non-integer chunk size', () => {
+  // Test case 6: Non-integer chunk size
+  it('6. should handle non-integer chunk size', () => {
     expect(chunkArray([1, 2, 3, 4], 2.5)).toEqual([
       [1, 2],
       [3, 4],
     ]);
   });
 
-  // Test case 9: Array with different data types
-  it('9. should handle array with different data types', () => {
+  // Test case 7: Array with different data types
+  it('7. should handle array with different data types', () => {
     expect(chunkArray([1, 'a', true, null], 2)).toEqual([
       [1, 'a'],
       [true, null],
     ]);
   });
 
-  // Test case 10: Large arrays
-  it('10. should handle large arrays', () => {
+  // Test case 8: Large arrays
+  it('8. should handle large arrays', () => {
     const largeArray = Array.from({ length: 1000 }, (_, i) => i);
     const chunkSize = 100;
     const expectedChunks = Array.from({ length: 10 }, (_, i) =>
@@ -62,16 +52,16 @@ describe('chunkArray', () => {
     expect(chunkArray(largeArray, chunkSize)).toEqual(expectedChunks);
   });
 
-  // Test case 11: Arrays with special characters
-  it('11. should handle arrays with special characters', () => {
+  // Test case 9: Arrays with special characters
+  it('9. should handle arrays with special characters', () => {
     expect(chunkArray(['@', '#', '$', '%'], 2)).toEqual([
       ['@', '#'],
       ['$', '%'],
     ]);
   });
 
-  // Test case 12: Arrays with nested arrays
-  it('12. should handle arrays with nested arrays', () => {
+  // Test case 10: Arrays with nested arrays
+  it('10. should handle arrays with nested arrays', () => {
     expect(
       chunkArray(
         [
@@ -90,31 +80,31 @@ describe('chunkArray', () => {
     ]);
   });
 
-  // Test case 13: Arrays with null and undefined
-  it('13. should handle arrays with null and undefined', () => {
+  // Test case 11: Arrays with null and undefined
+  it('11. should handle arrays with null and undefined', () => {
     expect(chunkArray([null, undefined, 1, 2], 2)).toEqual([
       [null, undefined],
       [1, 2],
     ]);
   });
 
-  // Test case 14: Arrays with NaN values
-  it('14. should handle arrays with NaN values', () => {
+  // Test case 12: Arrays with NaN values
+  it('12. should handle arrays with NaN values', () => {
     expect(chunkArray([NaN, 1, NaN, 2], 2)).toEqual([
       [NaN, 1],
       [NaN, 2],
     ]);
   });
 
-  // Test case 15: Arrays with objects
-  it('15. should handle arrays with objects', () => {
+  // Test case 13: Arrays with objects
+  it('13. should handle arrays with objects', () => {
     const obj1 = { a: 1 };
     const obj2 = { b: 2 };
     expect(chunkArray([obj1, obj2, obj1], 2)).toEqual([[obj1, obj2], [obj1]]);
   });
 
-  // Test case 16: Arrays with functions
-  it('16. should handle arrays with functions', () => {
+  // Test case 14: Arrays with functions
+  it('14. should handle arrays with functions', () => {
     const func1 = () => {};
     const func2 = () => {};
     expect(chunkArray([func1, func2, func1], 2)).toEqual([
@@ -123,15 +113,15 @@ describe('chunkArray', () => {
     ]);
   });
 
-  // Test case 17: Arrays with symbols
-  it('17. should handle arrays with symbols', () => {
+  // Test case 15: Arrays with symbols
+  it('15. should handle arrays with symbols', () => {
     const sym1 = Symbol('a');
     const sym2 = Symbol('b');
     expect(chunkArray([sym1, sym2, sym1], 2)).toEqual([[sym1, sym2], [sym1]]);
   });
 
-  // Test case 18: Arrays with dates
-  it('18. should handle arrays with dates', () => {
+  // Test case 16: Arrays with dates
+  it('16. should handle arrays with dates', () => {
     const date1 = new Date(2020, 1, 1);
     const date2 = new Date(2021, 1, 1);
     expect(chunkArray([date1, date2, date1], 2)).toEqual([
@@ -140,8 +130,8 @@ describe('chunkArray', () => {
     ]);
   });
 
-  // Test case 19: Arrays with regex
-  it('19. should handle arrays with regex', () => {
+  // Test case 17: Arrays with regex
+  it('17. should handle arrays with regex', () => {
     const regex1 = /a/;
     const regex2 = /b/;
     expect(chunkArray([regex1, regex2, regex1], 2)).toEqual([
@@ -149,4 +139,15 @@ describe('chunkArray', () => {
       [regex1],
     ]);
   });
+
+  // Test case 18: Chunk size of 0 (invalid case)
+  it('18. should handle chunk size of 0', () => {
+    expect(() => chunkArray([1, 2, 3], 0)).toThrow();
+  });
+
+  // Test case 19: Negative chunk size (invalid case)
+  it('19. should handle negative chunk size', () => {
+    expect(() => chunkArray([1, 2, 3], -1)).toThrow();
+  });
+
 });

--- a/functionsUnittests/arrayFunctionsUnittests/generatePrimes.test.ts
+++ b/functionsUnittests/arrayFunctionsUnittests/generatePrimes.test.ts
@@ -51,31 +51,8 @@ describe('generatePrimes', () => {
     expect(generatePrimes(-5)).toEqual([]);
   });
 
-  // Test case 5: Error case - non-integer limit
-  it('5. should throw RangeError for non-integer limit', () => {
-    // Arrange
-    const limit = 10.5;
-    const expectedMessage = 'Limit must be an integer';
-
-    // Act & Assert
-    expect(() => generatePrimes(limit)).toThrow(RangeError);
-    expect(() => generatePrimes(limit)).toThrow(expectedMessage);
-  });
-
-  // Test case 6: Error case - float limit
-  it('6. should throw RangeError for floating point limit', () => {
-    // Arrange
-    const limits = [3.14, 7.5, 100.1];
-
-    // Act & Assert
-    limits.forEach((limit) => {
-      expect(() => generatePrimes(limit)).toThrow(RangeError);
-      expect(() => generatePrimes(limit)).toThrow('Limit must be an integer');
-    });
-  });
-
-  // Test case 7: Boundary condition - limit is 3
-  it('7. should return [2, 3] when limit is 3', () => {
+  // Test case 5: Boundary condition - limit is 3
+  it('5. should return [2, 3] when limit is 3', () => {
     // Arrange
     const limit = 3;
     const expected = [2, 3];
@@ -87,8 +64,8 @@ describe('generatePrimes', () => {
     expect(result).toEqual(expected);
   });
 
-  // Test case 8: Normal usage - limit is 30
-  it('8. should generate all prime numbers up to 30', () => {
+  // Test case 6: Normal usage - limit is 30
+  it('6. should generate all prime numbers up to 30', () => {
     // Arrange
     const limit = 30;
     const expected = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29];
@@ -100,8 +77,8 @@ describe('generatePrimes', () => {
     expect(result).toEqual(expected);
   });
 
-  // Test case 9: Normal usage - limit is 50
-  it('9. should generate all prime numbers up to 50', () => {
+  // Test case 7: Normal usage - limit is 50
+  it('7. should generate all prime numbers up to 50', () => {
     // Arrange
     const limit = 50;
     const expected = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47];
@@ -113,8 +90,8 @@ describe('generatePrimes', () => {
     expect(result).toEqual(expected);
   });
 
-  // Test case 10: Verify all returned numbers are actually prime
-  it('10. should return only prime numbers (verification)', () => {
+  // Test case 8: Verify all returned numbers are actually prime
+  it('8. should return only prime numbers (verification)', () => {
     // Arrange
     const limit = 100;
 
@@ -137,8 +114,8 @@ describe('generatePrimes', () => {
     });
   });
 
-  // Test case 11: Verify correct count of primes
-  it('11. should return correct number of primes for known values', () => {
+  // Test case 9: Verify correct count of primes
+  it('9. should return correct number of primes for known values', () => {
     // Arrange & Act & Assert
     // There are 25 primes up to 100
     expect(generatePrimes(100).length).toBe(25);
@@ -150,8 +127,8 @@ describe('generatePrimes', () => {
     expect(generatePrimes(20).length).toBe(8);
   });
 
-  // Test case 12: Performance test with larger limit
-  it('12. should handle larger limits efficiently', () => {
+  // Test case 10: Performance test with larger limit
+  it('10. should handle larger limits efficiently', () => {
     // Arrange
     const limit = 1000;
 
@@ -167,8 +144,8 @@ describe('generatePrimes', () => {
     expect(endTime - startTime).toBeLessThan(100); // Should complete within 100ms
   });
 
-  // Test case 13: Verify returned array is sorted
-  it('13. should return primes in ascending order', () => {
+  // Test case 11: Verify returned array is sorted
+  it('11. should return primes in ascending order', () => {
     // Arrange
     const limit = 50;
 
@@ -181,8 +158,8 @@ describe('generatePrimes', () => {
     }
   });
 
-  // Test case 14: Edge case - negative integer
-  it('14. should return empty array for negative integer', () => {
+  // Test case 12: Edge case - negative integer
+  it('12. should return empty array for negative integer', () => {
     // Arrange
     const limit = -10;
 
@@ -193,8 +170,8 @@ describe('generatePrimes', () => {
     expect(result).toEqual([]);
   });
 
-  // Test case 15: Verify no duplicates in result
-  it('15. should not contain duplicate primes', () => {
+  // Test case 13: Verify no duplicates in result
+  it('13. should not contain duplicate primes', () => {
     // Arrange
     const limit = 100;
 
@@ -206,8 +183,8 @@ describe('generatePrimes', () => {
     expect(result.length).toBe(uniqueResult.length);
   });
 
-  // Test case 16: Edge case - large prime numbers near limit
-  it('16. should include prime numbers close to the limit', () => {
+  // Test case 14: Edge case - large prime numbers near limit
+  it('14. should include prime numbers close to the limit', () => {
     // Arrange
     const limit = 100;
 
@@ -219,8 +196,8 @@ describe('generatePrimes', () => {
     expect(result[result.length - 1]).toBe(97);
   });
 
-  // Test case 17: Verify first few primes are correct
-  it('17. should correctly identify the first 10 prime numbers', () => {
+  // Test case 15: Verify first few primes are correct
+  it('15. should correctly identify the first 10 prime numbers', () => {
     // Arrange
     const limit = 30;
     const expected = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29];
@@ -232,18 +209,8 @@ describe('generatePrimes', () => {
     expect(result).toEqual(expected);
   });
 
-  // Test case 18: Error case - NaN should throw error
-  it('18. should throw RangeError for NaN', () => {
-    // Arrange
-    const limit = NaN;
-
-    // Act & Assert
-    expect(() => generatePrimes(limit)).toThrow(RangeError);
-    expect(() => generatePrimes(limit)).toThrow('Limit must be an integer');
-  });
-
-  // Test case 19: Verify limit is inclusive
-  it('19. should include the limit if it is prime', () => {
+  // Test case 16: Verify limit is inclusive
+  it('16. should include the limit if it is prime', () => {
     // Arrange
     const limit = 13; // 13 is prime
 
@@ -255,8 +222,8 @@ describe('generatePrimes', () => {
     expect(result[result.length - 1]).toBe(13);
   });
 
-  // Test case 20: Verify limit is not included if not prime
-  it('20. should not include the limit if it is not prime', () => {
+  // Test case 17: Verify limit is not included if not prime
+  it('17. should not include the limit if it is not prime', () => {
     // Arrange
     const limit = 15; // 15 is not prime (3 * 5)
 
@@ -267,4 +234,38 @@ describe('generatePrimes', () => {
     expect(result).not.toContain(15);
     expect(result[result.length - 1]).toBe(13); // Last prime before 15
   });
+
+  // Test case 18: Error case - non-integer limit
+  it('18. should throw RangeError for non-integer limit', () => {
+    // Arrange
+    const limit = 10.5;
+    const expectedMessage = 'Limit must be an integer';
+
+    // Act & Assert
+    expect(() => generatePrimes(limit)).toThrow(RangeError);
+    expect(() => generatePrimes(limit)).toThrow(expectedMessage);
+  });
+
+  // Test case 19: Error case - float limit
+  it('19. should throw RangeError for floating point limit', () => {
+    // Arrange
+    const limits = [3.14, 7.5, 100.1];
+
+    // Act & Assert
+    limits.forEach((limit) => {
+      expect(() => generatePrimes(limit)).toThrow(RangeError);
+      expect(() => generatePrimes(limit)).toThrow('Limit must be an integer');
+    });
+  });
+
+  // Test case 20: Error case - NaN should throw error
+  it('20. should throw RangeError for NaN', () => {
+    // Arrange
+    const limit = NaN;
+
+    // Act & Assert
+    expect(() => generatePrimes(limit)).toThrow(RangeError);
+    expect(() => generatePrimes(limit)).toThrow('Limit must be an integer');
+  });
+
 });

--- a/functionsUnittests/arrayFunctionsUnittests/removeFalsyValues.test.ts
+++ b/functionsUnittests/arrayFunctionsUnittests/removeFalsyValues.test.ts
@@ -63,7 +63,7 @@ describe('removeFalsyValues', () => {
     expect(result).toEqual([1, 'apple', true]);
   });
 
-  // Test case 7: Removing falsy values from an array with objects
+  // Test case 6: Removing falsy values from an array with objects
   test('6. should remove falsy values from an array with objects', () => {
     const array: ({ id: number; name: string } | null | undefined | boolean)[] =
       [
@@ -80,28 +80,28 @@ describe('removeFalsyValues', () => {
     ]);
   });
 
-  // Test case 8: Removing falsy values from an array with null values
+  // Test case 7: Removing falsy values from an array with null values
   test('7. should remove falsy values from an array with null values', () => {
     const array: (number | null)[] = [1, null, 2, null, 3];
     const result: number[] = removeFalsyValues(array);
     expect(result).toEqual([1, 2, 3]);
   });
 
-  // Test case 9: Removing falsy values from an array with undefined values
+  // Test case 8: Removing falsy values from an array with undefined values
   test('8. should remove falsy values from an array with undefined values', () => {
     const array: (number | undefined)[] = [1, undefined, 2, undefined, 3];
     const result: number[] = removeFalsyValues(array);
     expect(result).toEqual([1, 2, 3]);
   });
 
-  // Test case 10: Removing falsy values from an array with boolean values
+  // Test case 9: Removing falsy values from an array with boolean values
   test('9. should remove falsy values from an array with boolean values', () => {
     const array: (number | boolean)[] = [1, false, 2, true, 3];
     const result: (number | boolean)[] = removeFalsyValues(array);
     expect(result).toEqual([1, 2, true, 3]);
   });
 
-  // Test case 11: Removing falsy values from an array with symbols
+  // Test case 10: Removing falsy values from an array with symbols
   test('10. should remove falsy values from an array with symbols', () => {
     const sym1: symbol = Symbol('sym1');
     const sym2: symbol = Symbol('sym2');
@@ -118,7 +118,7 @@ describe('removeFalsyValues', () => {
     expect(result).toEqual([1, sym1, sym2, 3]);
   });
 
-  // Test case 12: Removing falsy values from an array with functions
+  // Test case 11: Removing falsy values from an array with functions
   test('11. should remove falsy values from an array with functions', () => {
     const func1: () => void = () => {};
     const func2: () => void = () => {};
@@ -135,7 +135,7 @@ describe('removeFalsyValues', () => {
     expect(result).toEqual([1, func1, func2, 3]);
   });
 
-  // Test case 13: Removing falsy values from an array with dates
+  // Test case 12: Removing falsy values from an array with dates
   test('12. should remove falsy values from an array with dates', () => {
     const date1: Date = new Date('2021-01-01');
     const date2: Date = new Date('2022-01-01');
@@ -152,7 +152,7 @@ describe('removeFalsyValues', () => {
     expect(result).toEqual([1, date1, date2, 3]);
   });
 
-  // Test case 14: Removing falsy values from an array with regular expressions
+  // Test case 13: Removing falsy values from an array with regular expressions
   test('13. should remove falsy values from an array with regular expressions', () => {
     const regex1: RegExp = /abc/;
     const regex2: RegExp = /def/;
@@ -169,7 +169,7 @@ describe('removeFalsyValues', () => {
     expect(result).toEqual([1, regex1, regex2, 3]);
   });
 
-  // Test case 15: Removing falsy values from an array with BigInt values
+  // Test case 14: Removing falsy values from an array with BigInt values
   test('14. should remove falsy values from an array with BigInt values', () => {
     const array: (number | bigint | null | undefined | boolean)[] = [
       1,
@@ -184,7 +184,7 @@ describe('removeFalsyValues', () => {
     expect(result).toEqual([1, BigInt(2), BigInt(3), 3]);
   });
 
-  // Test case 16: Removing falsy values from an array with Infinity and -Infinity
+  // Test case 15: Removing falsy values from an array with Infinity and -Infinity
   test('15. should remove falsy values from an array with Infinity and -Infinity', () => {
     const array: (number | null | undefined | boolean)[] = [
       1,
@@ -199,7 +199,7 @@ describe('removeFalsyValues', () => {
     expect(result).toEqual([1, Infinity, -Infinity, 3]);
   });
 
-  // Test case 17: Removing falsy values from an array with NaN values
+  // Test case 16: Removing falsy values from an array with NaN values
   test('16. should remove falsy values from an array with NaN values', () => {
     const array: (number | null | undefined | boolean)[] = [
       1,
@@ -214,7 +214,7 @@ describe('removeFalsyValues', () => {
     expect(result).toEqual([1, 3]);
   });
 
-  // Test case 18: Removing falsy values from an array with mixed data types
+  // Test case 17: Removing falsy values from an array with mixed data types
   test('17. should remove falsy values from an array with mixed data types', () => {
     const array: (number | string | boolean | null | undefined)[] = [
       0,
@@ -230,7 +230,7 @@ describe('removeFalsyValues', () => {
     expect(result).toEqual(['apple', 'banana', 3]);
   });
 
-  // Test case 19: Removing falsy values from an array with symbols and functions
+  // Test case 18: Removing falsy values from an array with symbols and functions
   test('18. should remove falsy values from an array with symbols and functions', () => {
     const sym1: symbol = Symbol('sym1');
     const func1: () => void = () => {};
@@ -246,7 +246,7 @@ describe('removeFalsyValues', () => {
     expect(result).toEqual([1, sym1, func1, 3]);
   });
 
-  // Test case 20: Removing falsy values from an array with dates and regular expressions
+  // Test case 19: Removing falsy values from an array with dates and regular expressions
   test('19. should remove falsy values from an array with dates and regular expressions', () => {
     const date1: Date = new Date('2021-01-01');
     const regex1: RegExp = /abc/;
@@ -263,7 +263,7 @@ describe('removeFalsyValues', () => {
     expect(result).toEqual([1, date1, regex1, 3]);
   });
 
-  // Test case 21: Removing falsy values from an array with BigInt and Infinity values
+  // Test case 20: Removing falsy values from an array with BigInt and Infinity values
   test('20. should remove falsy values from an array with BigInt and Infinity values', () => {
     const array: (number | bigint | null | undefined | boolean)[] = [
       1,
@@ -278,7 +278,7 @@ describe('removeFalsyValues', () => {
     expect(result).toEqual([1, BigInt(2), Infinity, 3]);
   });
 
-  // Test case 22: Removing falsy values from an array with NaN and undefined values
+  // Test case 21: Removing falsy values from an array with NaN and undefined values
   test('21. should remove falsy values from an array with NaN and undefined values', () => {
     const array: (number | null | undefined | boolean)[] = [
       1,
@@ -293,14 +293,14 @@ describe('removeFalsyValues', () => {
     expect(result).toEqual([1, 3]);
   });
 
-  // Test case 23: Removing falsy values from an array with null and boolean values
+  // Test case 22: Removing falsy values from an array with null and boolean values
   test('22. should remove falsy values from an array with null and boolean values', () => {
     const array: (number | null | boolean)[] = [1, null, 1, true, null];
     const result: (number | boolean)[] = removeFalsyValues(array);
     expect(result).toEqual([1, 1, true]);
   });
 
-  // Test case 24: Removing falsy values from an array with mixed data types and symbols
+  // Test case 23: Removing falsy values from an array with mixed data types and symbols
   test('23. should remove falsy values from an array with mixed data types and symbols', () => {
     const sym1: symbol = Symbol('sym1');
     const array: (number | string | boolean | null | undefined | symbol)[] = [
@@ -317,7 +317,7 @@ describe('removeFalsyValues', () => {
     expect(result).toEqual([1, 'two', true, sym1, 'two', 1]);
   });
 
-  // Test case 25: Removing falsy values from an array with mixed data types and functions
+  // Test case 24: Removing falsy values from an array with mixed data types and functions
   test('24. should remove falsy values from an array with mixed data types and functions', () => {
     const func1: () => void = () => {};
     const array: (

--- a/functionsUnittests/asyncFunctionsUnittest/asyncFilter.test.ts
+++ b/functionsUnittests/asyncFunctionsUnittest/asyncFilter.test.ts
@@ -66,8 +66,51 @@ describe('asyncFilter', () => {
     expect(result).toEqual([]);
   });
 
-  // Test case 5: TypeError for invalid input types
-  it('5. should throw TypeError for invalid input types', () => {
+  // Test case 5: Predicate receives correct arguments
+  it('5. should pass item and index to predicate function', async () => {
+    // Arrange
+    const items = ['a', 'b', 'c'];
+    const predicateMock = jest.fn().mockResolvedValue(true);
+
+    // Act
+    await asyncFilter(items, predicateMock);
+
+    // Assert
+    expect(predicateMock).toHaveBeenCalledTimes(3);
+    expect(predicateMock).toHaveBeenNthCalledWith(1, 'a', 0);
+    expect(predicateMock).toHaveBeenNthCalledWith(2, 'b', 1);
+    expect(predicateMock).toHaveBeenNthCalledWith(3, 'c', 2);
+  });
+
+  // Test case 6: Predicates execute in parallel
+  it('6. should execute predicates in parallel for better performance', async () => {
+    // Arrange
+    const items = [1, 2, 3, 4];
+    const executionTimes: number[] = [];
+    const slowPredicate = async (item: number) => {
+      executionTimes.push(Date.now());
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return item % 2 === 0;
+    };
+
+    // Act
+    const start = Date.now();
+    const result = await asyncFilter(items, slowPredicate);
+    const totalTime = Date.now() - start;
+
+    // Assert
+    expect(result).toEqual([2, 4]);
+    expect(totalTime).toBeLessThan(100); // Should be closer to 50ms than 200ms
+
+    // All predicates should start at roughly the same time
+    const timeDifferences = executionTimes
+      .slice(1)
+      .map((time, i) => Math.abs(time - executionTimes[i]));
+    timeDifferences.forEach((diff) => expect(diff).toBeLessThan(20));
+  });
+
+  // Test case 7: TypeError for invalid input types
+  it('7. should throw TypeError for invalid input types', () => {
     // Arrange
     const invalidInputs = [123, null, undefined, {}, true, 'string'];
     const mockPredicate = jest.fn().mockResolvedValue(true);
@@ -83,8 +126,8 @@ describe('asyncFilter', () => {
     });
   });
 
-  // Test case 6: TypeError for invalid predicate
-  it('6. should throw TypeError for invalid predicate function', () => {
+  // Test case 8: TypeError for invalid predicate
+  it('8. should throw TypeError for invalid predicate function', () => {
     // Arrange
     const validArray = [1, 2, 3];
     const invalidPredicates = [123, null, undefined, {}, true, 'string'];
@@ -112,46 +155,4 @@ describe('asyncFilter', () => {
     });
   });
 
-  // Test case 7: Predicate receives correct arguments
-  it('7. should pass item and index to predicate function', async () => {
-    // Arrange
-    const items = ['a', 'b', 'c'];
-    const predicateMock = jest.fn().mockResolvedValue(true);
-
-    // Act
-    await asyncFilter(items, predicateMock);
-
-    // Assert
-    expect(predicateMock).toHaveBeenCalledTimes(3);
-    expect(predicateMock).toHaveBeenNthCalledWith(1, 'a', 0);
-    expect(predicateMock).toHaveBeenNthCalledWith(2, 'b', 1);
-    expect(predicateMock).toHaveBeenNthCalledWith(3, 'c', 2);
-  });
-
-  // Test case 8: Predicates execute in parallel
-  it('8. should execute predicates in parallel for better performance', async () => {
-    // Arrange
-    const items = [1, 2, 3, 4];
-    const executionTimes: number[] = [];
-    const slowPredicate = async (item: number) => {
-      executionTimes.push(Date.now());
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      return item % 2 === 0;
-    };
-
-    // Act
-    const start = Date.now();
-    const result = await asyncFilter(items, slowPredicate);
-    const totalTime = Date.now() - start;
-
-    // Assert
-    expect(result).toEqual([2, 4]);
-    expect(totalTime).toBeLessThan(100); // Should be closer to 50ms than 200ms
-
-    // All predicates should start at roughly the same time
-    const timeDifferences = executionTimes
-      .slice(1)
-      .map((time, i) => Math.abs(time - executionTimes[i]));
-    timeDifferences.forEach((diff) => expect(diff).toBeLessThan(20));
-  });
 });

--- a/functionsUnittests/asyncFunctionsUnittest/asyncMap.test.ts
+++ b/functionsUnittests/asyncFunctionsUnittest/asyncMap.test.ts
@@ -55,88 +55,8 @@ describe('asyncMap', () => {
     expect(mockFn).toHaveBeenNthCalledWith(3, 'c', 2);
   });
 
-  // Test case 4: Error handling
-  it('4. should propagate errors from async function', async () => {
-    // Arrange
-    const numbers = [1, 2, 3];
-    const errorFn = (num: number) => {
-      if (num === 2) {
-        throw new Error('Error on second item');
-      }
-      return Promise.resolve(num * 2);
-    };
-
-    // Act & Assert
-    await expect(asyncMap(numbers, errorFn)).rejects.toThrow(
-      'Error on second item',
-    );
-  });
-
-  // Test case 5: TypeError for invalid input types
-  it('5. should throw TypeError for invalid input types', () => {
-    // Arrange
-    const invalidInputs = [123, null, undefined, {}, true, 'string'];
-    const mockFn = jest.fn().mockResolvedValue('test');
-
-    // Act & Assert
-    invalidInputs.forEach((input) => {
-      expect(() => asyncMap(input as unknown as unknown[], mockFn)).toThrow(
-        TypeError,
-      );
-      expect(() => asyncMap(input as unknown as unknown[], mockFn)).toThrow(
-        'array must be an array, got',
-      );
-    });
-  });
-
-  // Test case 6: TypeError for invalid async function
-  it('6. should throw TypeError for invalid async function', () => {
-    // Arrange
-    const validArray = [1, 2, 3];
-    const invalidFunctions = [123, null, undefined, {}, true, 'string', []];
-
-    // Act & Assert
-    invalidFunctions.forEach((fn) => {
-      expect(() =>
-        asyncMap(
-          validArray,
-          fn as unknown as (item: number, index: number) => Promise<unknown>,
-        ),
-      ).toThrow(TypeError);
-      expect(() =>
-        asyncMap(
-          validArray,
-          fn as unknown as (item: number, index: number) => Promise<unknown>,
-        ),
-      ).toThrow('asyncFn must be a function, got');
-    });
-  });
-
-  // Test case 7: Invalid concurrency
-  it('7. should throw TypeError for invalid concurrency', () => {
-    // Arrange
-    const validArray = [1, 2, 3];
-    const validFn = jest.fn().mockResolvedValue('test');
-    const invalidConcurrency = [null, undefined, {}, true, 'string', [], NaN];
-
-    // Act & Assert
-    invalidConcurrency.forEach((concurrency) => {
-      expect(() =>
-        asyncMap(validArray, validFn, concurrency as unknown as number),
-      ).toThrow(TypeError);
-      expect(() =>
-        asyncMap(validArray, validFn, concurrency as unknown as number),
-      ).toThrow('concurrency must be a number, got');
-    });
-
-    expect(() => asyncMap(validArray, validFn, 0)).toThrow(Error);
-    expect(() => asyncMap(validArray, validFn, 0)).toThrow(
-      'concurrency must be at least 1, got 0',
-    );
-  });
-
-  // Test case 8: Performance test with concurrency
-  it('8. should process items with respect to concurrency limit', async () => {
+  // Test case 4: Performance test with concurrency
+  it('4. should process items with respect to concurrency limit', async () => {
     // Arrange
     const items = [1, 2, 3, 4, 5, 6];
     let activeCount = 0;
@@ -158,8 +78,8 @@ describe('asyncMap', () => {
     expect(maxActiveCount).toBeLessThanOrEqual(3);
   });
 
-  // Test case 9: Small array should use Promise.all
-  it('9. should use Promise.all for small arrays', async () => {
+  // Test case 5: Small array should use Promise.all
+  it('5. should use Promise.all for small arrays', async () => {
     // Arrange
     const items = [1, 2];
     const mockFn = jest
@@ -174,8 +94,8 @@ describe('asyncMap', () => {
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
-  // Test case 10: Different data types
-  it('10. should handle different input and output types', async () => {
+  // Test case 6: Different data types
+  it('6. should handle different input and output types', async () => {
     // Arrange
     const strings = ['hello', 'world', 'test'];
     const lengthFn = async (str: string) => {
@@ -189,4 +109,85 @@ describe('asyncMap', () => {
     // Assert
     expect(result).toEqual([5, 5, 4]);
   });
+
+  // Test case 7: Error handling
+  it('7. should propagate errors from async function', async () => {
+    // Arrange
+    const numbers = [1, 2, 3];
+    const errorFn = (num: number) => {
+      if (num === 2) {
+        throw new Error('Error on second item');
+      }
+      return Promise.resolve(num * 2);
+    };
+
+    // Act & Assert
+    await expect(asyncMap(numbers, errorFn)).rejects.toThrow(
+      'Error on second item',
+    );
+  });
+
+  // Test case 8: TypeError for invalid input types
+  it('8. should throw TypeError for invalid input types', () => {
+    // Arrange
+    const invalidInputs = [123, null, undefined, {}, true, 'string'];
+    const mockFn = jest.fn().mockResolvedValue('test');
+
+    // Act & Assert
+    invalidInputs.forEach((input) => {
+      expect(() => asyncMap(input as unknown as unknown[], mockFn)).toThrow(
+        TypeError,
+      );
+      expect(() => asyncMap(input as unknown as unknown[], mockFn)).toThrow(
+        'array must be an array, got',
+      );
+    });
+  });
+
+  // Test case 9: TypeError for invalid async function
+  it('9. should throw TypeError for invalid async function', () => {
+    // Arrange
+    const validArray = [1, 2, 3];
+    const invalidFunctions = [123, null, undefined, {}, true, 'string', []];
+
+    // Act & Assert
+    invalidFunctions.forEach((fn) => {
+      expect(() =>
+        asyncMap(
+          validArray,
+          fn as unknown as (item: number, index: number) => Promise<unknown>,
+        ),
+      ).toThrow(TypeError);
+      expect(() =>
+        asyncMap(
+          validArray,
+          fn as unknown as (item: number, index: number) => Promise<unknown>,
+        ),
+      ).toThrow('asyncFn must be a function, got');
+    });
+  });
+
+  // Test case 10: Invalid concurrency
+  it('10. should throw TypeError for invalid concurrency', () => {
+    // Arrange
+    const validArray = [1, 2, 3];
+    const validFn = jest.fn().mockResolvedValue('test');
+    const invalidConcurrency = [null, undefined, {}, true, 'string', [], NaN];
+
+    // Act & Assert
+    invalidConcurrency.forEach((concurrency) => {
+      expect(() =>
+        asyncMap(validArray, validFn, concurrency as unknown as number),
+      ).toThrow(TypeError);
+      expect(() =>
+        asyncMap(validArray, validFn, concurrency as unknown as number),
+      ).toThrow('concurrency must be a number, got');
+    });
+
+    expect(() => asyncMap(validArray, validFn, 0)).toThrow(Error);
+    expect(() => asyncMap(validArray, validFn, 0)).toThrow(
+      'concurrency must be at least 1, got 0',
+    );
+  });
+
 });

--- a/functionsUnittests/asyncFunctionsUnittest/asyncParallel.test.ts
+++ b/functionsUnittests/asyncFunctionsUnittest/asyncParallel.test.ts
@@ -69,87 +69,8 @@ describe('asyncParallel', () => {
     expect(maxActiveCount).toBeLessThanOrEqual(2);
   });
 
-  // Test case 4: Error handling
-  it('4. should propagate errors from tasks', async () => {
-    // Arrange
-    const tasks = [
-      jest.fn().mockResolvedValue('result1'),
-      jest.fn().mockRejectedValue(new Error('Task failed')),
-      jest.fn().mockResolvedValue('result3'),
-    ];
-
-    // Act & Assert
-    await expect(asyncParallel(tasks)).rejects.toThrow('Task failed');
-  });
-
-  // Test case 5: TypeError for invalid input types
-  it('5. should throw TypeError for invalid input types', () => {
-    // Arrange
-    const invalidInputs = [123, null, undefined, {}, true, 'string'];
-
-    // Act & Assert
-    invalidInputs.forEach((input) => {
-      expect(() =>
-        asyncParallel(input as unknown as (() => Promise<unknown>)[]),
-      ).toThrow(TypeError);
-      expect(() =>
-        asyncParallel(input as unknown as (() => Promise<unknown>)[]),
-      ).toThrow('tasks must be an array, got');
-    });
-  });
-
-  // Test case 6: TypeError for invalid concurrency
-  it('6. should throw TypeError for invalid concurrency', () => {
-    // Arrange
-    const validTasks = [jest.fn().mockResolvedValue('test')];
-    const invalidConcurrency = [null, undefined, {}, true, 'string', [], NaN];
-
-    // Act & Assert
-    invalidConcurrency.forEach((concurrency) => {
-      expect(() =>
-        asyncParallel(validTasks, concurrency as unknown as number),
-      ).toThrow(TypeError);
-      expect(() =>
-        asyncParallel(validTasks, concurrency as unknown as number),
-      ).toThrow('concurrency must be a number, got');
-    });
-  });
-
-  // Test case 7: Error for invalid concurrency value
-  it('7. should throw Error for concurrency less than 1', () => {
-    // Arrange
-    const validTasks = [jest.fn().mockResolvedValue('test')];
-
-    // Act & Assert
-    expect(() => asyncParallel(validTasks, 0)).toThrow(Error);
-    expect(() => asyncParallel(validTasks, 0)).toThrow(
-      'concurrency must be at least 1, got 0',
-    );
-
-    expect(() => asyncParallel(validTasks, -1)).toThrow(Error);
-    expect(() => asyncParallel(validTasks, -1)).toThrow(
-      'concurrency must be at least 1, got -1',
-    );
-  });
-
-  // Test case 8: Error for non-function tasks
-  it('8. should throw Error for non-function tasks', () => {
-    // Arrange
-    const invalidTasks = [123, null, undefined, {}, true, 'string'];
-
-    // Act & Assert
-    invalidTasks.forEach((task, _index) => {
-      expect(() =>
-        asyncParallel([task as unknown as () => Promise<unknown>]),
-      ).toThrow(Error);
-      expect(() =>
-        asyncParallel([task as unknown as () => Promise<unknown>]),
-      ).toThrow('Task at index 0 must be a function, got');
-    });
-  });
-
-  // Test case 9: Results maintain order
-  it('9. should maintain order of results regardless of completion time', async () => {
+  // Test case 4: Results maintain order
+  it('4. should maintain order of results regardless of completion time', async () => {
     // Arrange
     const tasks = [
       async () => {
@@ -173,8 +94,8 @@ describe('asyncParallel', () => {
     expect(results).toEqual(['slow', 'fast', 'medium']);
   });
 
-  // Test case 10: Performance test
-  it('10. should execute tasks in parallel for better performance', async () => {
+  // Test case 5: Performance test
+  it('5. should execute tasks in parallel for better performance', async () => {
     // Arrange
     const tasks = Array.from({ length: 4 }, (_, i) => async () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
@@ -190,4 +111,84 @@ describe('asyncParallel', () => {
     expect(results).toHaveLength(4);
     expect(totalTime).toBeLessThan(100); // Should be closer to 50ms than 200ms
   });
+
+  // Test case 6: Error handling
+  it('6. should propagate errors from tasks', async () => {
+    // Arrange
+    const tasks = [
+      jest.fn().mockResolvedValue('result1'),
+      jest.fn().mockRejectedValue(new Error('Task failed')),
+      jest.fn().mockResolvedValue('result3'),
+    ];
+
+    // Act & Assert
+    await expect(asyncParallel(tasks)).rejects.toThrow('Task failed');
+  });
+
+  // Test case 7: TypeError for invalid input types
+  it('7. should throw TypeError for invalid input types', () => {
+    // Arrange
+    const invalidInputs = [123, null, undefined, {}, true, 'string'];
+
+    // Act & Assert
+    invalidInputs.forEach((input) => {
+      expect(() =>
+        asyncParallel(input as unknown as (() => Promise<unknown>)[]),
+      ).toThrow(TypeError);
+      expect(() =>
+        asyncParallel(input as unknown as (() => Promise<unknown>)[]),
+      ).toThrow('tasks must be an array, got');
+    });
+  });
+
+  // Test case 8: TypeError for invalid concurrency
+  it('8. should throw TypeError for invalid concurrency', () => {
+    // Arrange
+    const validTasks = [jest.fn().mockResolvedValue('test')];
+    const invalidConcurrency = [null, undefined, {}, true, 'string', [], NaN];
+
+    // Act & Assert
+    invalidConcurrency.forEach((concurrency) => {
+      expect(() =>
+        asyncParallel(validTasks, concurrency as unknown as number),
+      ).toThrow(TypeError);
+      expect(() =>
+        asyncParallel(validTasks, concurrency as unknown as number),
+      ).toThrow('concurrency must be a number, got');
+    });
+  });
+
+  // Test case 9: Error for invalid concurrency value
+  it('9. should throw Error for concurrency less than 1', () => {
+    // Arrange
+    const validTasks = [jest.fn().mockResolvedValue('test')];
+
+    // Act & Assert
+    expect(() => asyncParallel(validTasks, 0)).toThrow(Error);
+    expect(() => asyncParallel(validTasks, 0)).toThrow(
+      'concurrency must be at least 1, got 0',
+    );
+
+    expect(() => asyncParallel(validTasks, -1)).toThrow(Error);
+    expect(() => asyncParallel(validTasks, -1)).toThrow(
+      'concurrency must be at least 1, got -1',
+    );
+  });
+
+  // Test case 10: Error for non-function tasks
+  it('10. should throw Error for non-function tasks', () => {
+    // Arrange
+    const invalidTasks = [123, null, undefined, {}, true, 'string'];
+
+    // Act & Assert
+    invalidTasks.forEach((task, _index) => {
+      expect(() =>
+        asyncParallel([task as unknown as () => Promise<unknown>]),
+      ).toThrow(Error);
+      expect(() =>
+        asyncParallel([task as unknown as () => Promise<unknown>]),
+      ).toThrow('Task at index 0 must be a function, got');
+    });
+  });
+
 });

--- a/functionsUnittests/asyncFunctionsUnittest/asyncRetry.test.ts
+++ b/functionsUnittests/asyncFunctionsUnittest/asyncRetry.test.ts
@@ -36,75 +36,8 @@ describe('asyncRetry', () => {
     expect(mockFn).toHaveBeenCalledTimes(3);
   });
 
-  // Test case 3: All attempts fail
-  it('3. should throw last error when all attempts fail', async () => {
-    // Arrange
-    const expectedError = new Error('Final attempt failed');
-    const mockFn = jest
-      .fn()
-      .mockRejectedValueOnce(new Error('Attempt 1 failed'))
-      .mockRejectedValueOnce(new Error('Attempt 2 failed'))
-      .mockRejectedValue(expectedError);
-
-    // Act & Assert
-    await expect(
-      asyncRetry(mockFn, { maxAttempts: 3, delay: 10 }),
-    ).rejects.toThrow('Final attempt failed');
-    expect(mockFn).toHaveBeenCalledTimes(3);
-  });
-
-  // Test case 4: TypeError for invalid input types
-  it('4. should throw TypeError for invalid input types', () => {
-    // Arrange
-    const invalidInputs = [123, null, undefined, [], {}, true, 'string'];
-
-    // Act & Assert
-    invalidInputs.forEach((input) => {
-      expect(() =>
-        asyncRetry(input as unknown as () => Promise<unknown>),
-      ).toThrow(TypeError);
-      expect(() =>
-        asyncRetry(input as unknown as () => Promise<unknown>),
-      ).toThrow('fn must be a function, got');
-    });
-  });
-
-  // Test case 5: Error for invalid options
-  it('5. should throw Error for invalid options', () => {
-    // Arrange
-    const mockFn = jest.fn().mockResolvedValue('success');
-
-    // Act & Assert
-    expect(() => asyncRetry(mockFn, { maxAttempts: 0 })).toThrow(
-      'maxAttempts must be a positive number',
-    );
-
-    expect(() => asyncRetry(mockFn, { maxAttempts: -1 })).toThrow(
-      'maxAttempts must be a positive number',
-    );
-
-    expect(() => asyncRetry(mockFn, { delay: -100 })).toThrow(
-      'delay must be a non-negative number',
-    );
-
-    expect(() =>
-      asyncRetry(mockFn, {
-        backoff: 'invalid' as 'fixed' | 'linear' | 'exponential',
-      }),
-    ).toThrow("backoff must be 'fixed', 'linear', or 'exponential'");
-
-    expect(() =>
-      asyncRetry(mockFn, {
-        onRetry: 'not a function' as unknown as (
-          attempt: number,
-          error: Error,
-        ) => void,
-      }),
-    ).toThrow('onRetry must be a function');
-  });
-
-  // Test case 6: Backoff strategies
-  it('6. should implement different backoff strategies correctly', async () => {
+  // Test case 3: Backoff strategies
+  it('3. should implement different backoff strategies correctly', async () => {
     // Arrange
     const delays: number[] = [];
     const originalSetTimeout = global.setTimeout;
@@ -159,8 +92,8 @@ describe('asyncRetry', () => {
     global.setTimeout = originalSetTimeout;
   });
 
-  // Test case 7: onRetry callback
-  it('7. should call onRetry callback on each retry', async () => {
+  // Test case 4: onRetry callback
+  it('4. should call onRetry callback on each retry', async () => {
     // Arrange
     const onRetryMock = jest.fn();
     const mockFn = jest
@@ -182,8 +115,8 @@ describe('asyncRetry', () => {
     expect(onRetryMock).toHaveBeenNthCalledWith(2, 2, expect.any(Error));
   });
 
-  // Test case 8: Performance test with large input
-  it('8. should handle reasonable number of retries efficiently', async () => {
+  // Test case 5: Performance test with large input
+  it('5. should handle reasonable number of retries efficiently', async () => {
     // Arrange
     const mockFn = jest.fn().mockResolvedValue('success');
 
@@ -197,4 +130,72 @@ describe('asyncRetry', () => {
     expect(mockFn).toHaveBeenCalledTimes(1);
     expect(endTime - startTime).toBeLessThan(50); // Should complete quickly on first success
   });
+
+  // Test case 6: All attempts fail
+  it('6. should throw last error when all attempts fail', async () => {
+    // Arrange
+    const expectedError = new Error('Final attempt failed');
+    const mockFn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Attempt 1 failed'))
+      .mockRejectedValueOnce(new Error('Attempt 2 failed'))
+      .mockRejectedValue(expectedError);
+
+    // Act & Assert
+    await expect(
+      asyncRetry(mockFn, { maxAttempts: 3, delay: 10 }),
+    ).rejects.toThrow('Final attempt failed');
+    expect(mockFn).toHaveBeenCalledTimes(3);
+  });
+
+  // Test case 7: TypeError for invalid input types
+  it('7. should throw TypeError for invalid input types', () => {
+    // Arrange
+    const invalidInputs = [123, null, undefined, [], {}, true, 'string'];
+
+    // Act & Assert
+    invalidInputs.forEach((input) => {
+      expect(() =>
+        asyncRetry(input as unknown as () => Promise<unknown>),
+      ).toThrow(TypeError);
+      expect(() =>
+        asyncRetry(input as unknown as () => Promise<unknown>),
+      ).toThrow('fn must be a function, got');
+    });
+  });
+
+  // Test case 8: Error for invalid options
+  it('8. should throw Error for invalid options', () => {
+    // Arrange
+    const mockFn = jest.fn().mockResolvedValue('success');
+
+    // Act & Assert
+    expect(() => asyncRetry(mockFn, { maxAttempts: 0 })).toThrow(
+      'maxAttempts must be a positive number',
+    );
+
+    expect(() => asyncRetry(mockFn, { maxAttempts: -1 })).toThrow(
+      'maxAttempts must be a positive number',
+    );
+
+    expect(() => asyncRetry(mockFn, { delay: -100 })).toThrow(
+      'delay must be a non-negative number',
+    );
+
+    expect(() =>
+      asyncRetry(mockFn, {
+        backoff: 'invalid' as 'fixed' | 'linear' | 'exponential',
+      }),
+    ).toThrow("backoff must be 'fixed', 'linear', or 'exponential'");
+
+    expect(() =>
+      asyncRetry(mockFn, {
+        onRetry: 'not a function' as unknown as (
+          attempt: number,
+          error: Error,
+        ) => void,
+      }),
+    ).toThrow('onRetry must be a function');
+  });
+
 });

--- a/functionsUnittests/asyncFunctionsUnittest/asyncSeries.test.ts
+++ b/functionsUnittests/asyncFunctionsUnittest/asyncSeries.test.ts
@@ -43,64 +43,8 @@ describe('asyncSeries', () => {
     expect(results).toEqual([]);
   });
 
-  // Test case 3: Error handling
-  it('3. should stop execution on first error', async () => {
-    // Arrange
-    const executionOrder: number[] = [];
-    const tasks = [
-      () => {
-        executionOrder.push(1);
-        return Promise.resolve('result1');
-      },
-      () => {
-        executionOrder.push(2);
-        return Promise.reject(new Error('Task 2 failed'));
-      },
-      () => {
-        executionOrder.push(3);
-        return Promise.resolve('result3');
-      },
-    ];
-
-    // Act & Assert
-    await expect(asyncSeries(tasks)).rejects.toThrow('Task 2 failed');
-    expect(executionOrder).toEqual([1, 2]); // Third task should not execute
-  });
-
-  // Test case 4: TypeError for invalid input types
-  it('4. should throw TypeError for invalid input types', () => {
-    // Arrange
-    const invalidInputs = [123, null, undefined, {}, true, 'string'];
-
-    // Act & Assert
-    invalidInputs.forEach((input) => {
-      expect(() =>
-        asyncSeries(input as unknown as (() => Promise<unknown>)[]),
-      ).toThrow(TypeError);
-      expect(() =>
-        asyncSeries(input as unknown as (() => Promise<unknown>)[]),
-      ).toThrow('tasks must be an array, got');
-    });
-  });
-
-  // Test case 5: Error for non-function tasks
-  it('5. should throw Error for non-function tasks', () => {
-    // Arrange
-    const invalidTasks = [123, null, undefined, {}, true, 'string'];
-
-    // Act & Assert
-    invalidTasks.forEach((task) => {
-      expect(() =>
-        asyncSeries([task as unknown as () => Promise<unknown>]),
-      ).toThrow(Error);
-      expect(() =>
-        asyncSeries([task as unknown as () => Promise<unknown>]),
-      ).toThrow('Task at index 0 must be a function, got');
-    });
-  });
-
-  // Test case 6: Mixed data types in results
-  it('6. should handle mixed data types in results', async () => {
+  // Test case 3: Mixed data types in results
+  it('3. should handle mixed data types in results', async () => {
     // Arrange
     const tasks: Array<() => Promise<unknown>> = [
       () => Promise.resolve(42),
@@ -123,8 +67,8 @@ describe('asyncSeries', () => {
     ]);
   });
 
-  // Test case 7: Performance test
-  it('7. should execute tasks sequentially (not in parallel)', async () => {
+  // Test case 4: Performance test
+  it('4. should execute tasks sequentially (not in parallel)', async () => {
     // Arrange
     const startTimes: number[] = [];
     const tasks = Array.from({ length: 3 }, (_, i) => async () => {
@@ -148,8 +92,8 @@ describe('asyncSeries', () => {
     }
   });
 
-  // Test case 8: Single task
-  it('8. should handle single task correctly', async () => {
+  // Test case 5: Single task
+  it('5. should handle single task correctly', async () => {
     // Arrange
     const task = () => Promise.resolve('single result');
 
@@ -159,4 +103,61 @@ describe('asyncSeries', () => {
     // Assert
     expect(results).toEqual(['single result']);
   });
+
+  // Test case 6: Error handling
+  it('6. should stop execution on first error', async () => {
+    // Arrange
+    const executionOrder: number[] = [];
+    const tasks = [
+      () => {
+        executionOrder.push(1);
+        return Promise.resolve('result1');
+      },
+      () => {
+        executionOrder.push(2);
+        return Promise.reject(new Error('Task 2 failed'));
+      },
+      () => {
+        executionOrder.push(3);
+        return Promise.resolve('result3');
+      },
+    ];
+
+    // Act & Assert
+    await expect(asyncSeries(tasks)).rejects.toThrow('Task 2 failed');
+    expect(executionOrder).toEqual([1, 2]); // Third task should not execute
+  });
+
+  // Test case 7: TypeError for invalid input types
+  it('7. should throw TypeError for invalid input types', () => {
+    // Arrange
+    const invalidInputs = [123, null, undefined, {}, true, 'string'];
+
+    // Act & Assert
+    invalidInputs.forEach((input) => {
+      expect(() =>
+        asyncSeries(input as unknown as (() => Promise<unknown>)[]),
+      ).toThrow(TypeError);
+      expect(() =>
+        asyncSeries(input as unknown as (() => Promise<unknown>)[]),
+      ).toThrow('tasks must be an array, got');
+    });
+  });
+
+  // Test case 8: Error for non-function tasks
+  it('8. should throw Error for non-function tasks', () => {
+    // Arrange
+    const invalidTasks = [123, null, undefined, {}, true, 'string'];
+
+    // Act & Assert
+    invalidTasks.forEach((task) => {
+      expect(() =>
+        asyncSeries([task as unknown as () => Promise<unknown>]),
+      ).toThrow(Error);
+      expect(() =>
+        asyncSeries([task as unknown as () => Promise<unknown>]),
+      ).toThrow('Task at index 0 must be a function, got');
+    });
+  });
+
 });

--- a/functionsUnittests/asyncFunctionsUnittest/asyncTimeout.test.ts
+++ b/functionsUnittests/asyncFunctionsUnittest/asyncTimeout.test.ts
@@ -18,119 +18,8 @@ describe('asyncTimeout', () => {
     expect(result).toBe('success');
   });
 
-  // Test case 2: Promise times out
-  it('2. should throw timeout error when promise takes too long', async () => {
-    // Arrange
-    const promise = new Promise<string>((resolve) => {
-      setTimeout(() => resolve('too late'), 100);
-    });
-
-    // Act & Assert
-    await expect(asyncTimeout(promise, 50)).rejects.toThrow(
-      'Operation timed out',
-    );
-  });
-
-  // Test case 3: Custom timeout message
-  it('3. should use custom timeout message', async () => {
-    // Arrange
-    const promise = new Promise<string>((resolve) => {
-      setTimeout(() => resolve('too late'), 100);
-    });
-    const customMessage = 'Custom timeout error';
-
-    // Act & Assert
-    await expect(asyncTimeout(promise, 50, customMessage)).rejects.toThrow(
-      customMessage,
-    );
-  });
-
-  // Test case 4: Promise rejects before timeout
-  it('4. should propagate promise rejection', async () => {
-    // Arrange
-    const promise = Promise.reject(new Error('Promise failed'));
-
-    // Act & Assert
-    await expect(asyncTimeout(promise, 100)).rejects.toThrow('Promise failed');
-  });
-
-  // Test case 5: TypeError for invalid promise
-  it('5. should throw TypeError for invalid promise', () => {
-    // Arrange
-    const invalidPromises = [123, null, undefined, {}, true, 'string', []];
-
-    // Act & Assert
-    invalidPromises.forEach((promise) => {
-      expect(() =>
-        asyncTimeout(promise as unknown as Promise<unknown>, 100),
-      ).toThrow(TypeError);
-      expect(() =>
-        asyncTimeout(promise as unknown as Promise<unknown>, 100),
-      ).toThrow('promise must be a Promise, got');
-    });
-  });
-
-  // Test case 6: TypeError for invalid timeout
-  it('6. should throw TypeError for invalid timeout value', () => {
-    // Arrange
-    const validPromise = Promise.resolve('test');
-    const invalidTimeouts = [null, undefined, {}, true, 'string', [], NaN];
-
-    // Act & Assert
-    invalidTimeouts.forEach((timeout) => {
-      expect(() =>
-        asyncTimeout(validPromise, timeout as unknown as number),
-      ).toThrow(TypeError);
-      expect(() =>
-        asyncTimeout(validPromise, timeout as unknown as number),
-      ).toThrow('timeoutMs must be a number, got');
-    });
-  });
-
-  // Test case 7: Error for negative timeout
-  it('7. should throw Error for negative timeout', () => {
-    // Arrange
-    const validPromise = Promise.resolve('test');
-
-    // Act & Assert
-    expect(() => asyncTimeout(validPromise, -100)).toThrow(Error);
-    expect(() => asyncTimeout(validPromise, -100)).toThrow(
-      'timeoutMs must be non-negative, got -100',
-    );
-  });
-
-  // Test case 8: Error for invalid timeout message
-  it('8. should throw Error for invalid timeout message', () => {
-    // Arrange
-    const validPromise = Promise.resolve('test');
-    const invalidMessages = [123, null, undefined, {}, true, []];
-
-    // Act & Assert
-    invalidMessages.forEach((message) => {
-      expect(() =>
-        asyncTimeout(validPromise, 100, message as unknown as string),
-      ).toThrow(Error);
-      expect(() =>
-        asyncTimeout(validPromise, 100, message as unknown as string),
-      ).toThrow('timeoutMessage must be a string, got');
-    });
-  });
-
-  // Test case 9: Zero timeout
-  it('9. should handle zero timeout correctly', async () => {
-    // Arrange
-    const promise = new Promise<string>((resolve) => {
-      setTimeout(() => resolve('too late'), 10);
-    });
-
-    // Act & Assert
-    await expect(asyncTimeout(promise, 0)).rejects.toThrow(
-      'Operation timed out',
-    );
-  });
-
-  // Test case 10: Performance test
-  it('10. should timeout at approximately the right time', async () => {
+  // Test case 2: Performance test
+  it('2. should timeout at approximately the right time', async () => {
     // Arrange
     const promise = new Promise<string>((resolve) => {
       setTimeout(() => resolve('too late'), 200);
@@ -150,4 +39,116 @@ describe('asyncTimeout', () => {
       expect(error).toBeInstanceOf(Error);
     }
   });
+
+  // Test case 3: Promise times out
+  it('3. should throw timeout error when promise takes too long', async () => {
+    // Arrange
+    const promise = new Promise<string>((resolve) => {
+      setTimeout(() => resolve('too late'), 100);
+    });
+
+    // Act & Assert
+    await expect(asyncTimeout(promise, 50)).rejects.toThrow(
+      'Operation timed out',
+    );
+  });
+
+  // Test case 4: Custom timeout message
+  it('4. should use custom timeout message', async () => {
+    // Arrange
+    const promise = new Promise<string>((resolve) => {
+      setTimeout(() => resolve('too late'), 100);
+    });
+    const customMessage = 'Custom timeout error';
+
+    // Act & Assert
+    await expect(asyncTimeout(promise, 50, customMessage)).rejects.toThrow(
+      customMessage,
+    );
+  });
+
+  // Test case 5: Promise rejects before timeout
+  it('5. should propagate promise rejection', async () => {
+    // Arrange
+    const promise = Promise.reject(new Error('Promise failed'));
+
+    // Act & Assert
+    await expect(asyncTimeout(promise, 100)).rejects.toThrow('Promise failed');
+  });
+
+  // Test case 6: TypeError for invalid promise
+  it('6. should throw TypeError for invalid promise', () => {
+    // Arrange
+    const invalidPromises = [123, null, undefined, {}, true, 'string', []];
+
+    // Act & Assert
+    invalidPromises.forEach((promise) => {
+      expect(() =>
+        asyncTimeout(promise as unknown as Promise<unknown>, 100),
+      ).toThrow(TypeError);
+      expect(() =>
+        asyncTimeout(promise as unknown as Promise<unknown>, 100),
+      ).toThrow('promise must be a Promise, got');
+    });
+  });
+
+  // Test case 7: TypeError for invalid timeout
+  it('7. should throw TypeError for invalid timeout value', () => {
+    // Arrange
+    const validPromise = Promise.resolve('test');
+    const invalidTimeouts = [null, undefined, {}, true, 'string', [], NaN];
+
+    // Act & Assert
+    invalidTimeouts.forEach((timeout) => {
+      expect(() =>
+        asyncTimeout(validPromise, timeout as unknown as number),
+      ).toThrow(TypeError);
+      expect(() =>
+        asyncTimeout(validPromise, timeout as unknown as number),
+      ).toThrow('timeoutMs must be a number, got');
+    });
+  });
+
+  // Test case 8: Error for negative timeout
+  it('8. should throw Error for negative timeout', () => {
+    // Arrange
+    const validPromise = Promise.resolve('test');
+
+    // Act & Assert
+    expect(() => asyncTimeout(validPromise, -100)).toThrow(Error);
+    expect(() => asyncTimeout(validPromise, -100)).toThrow(
+      'timeoutMs must be non-negative, got -100',
+    );
+  });
+
+  // Test case 9: Error for invalid timeout message
+  it('9. should throw Error for invalid timeout message', () => {
+    // Arrange
+    const validPromise = Promise.resolve('test');
+    const invalidMessages = [123, null, undefined, {}, true, []];
+
+    // Act & Assert
+    invalidMessages.forEach((message) => {
+      expect(() =>
+        asyncTimeout(validPromise, 100, message as unknown as string),
+      ).toThrow(Error);
+      expect(() =>
+        asyncTimeout(validPromise, 100, message as unknown as string),
+      ).toThrow('timeoutMessage must be a string, got');
+    });
+  });
+
+  // Test case 10: Zero timeout
+  it('10. should handle zero timeout correctly', async () => {
+    // Arrange
+    const promise = new Promise<string>((resolve) => {
+      setTimeout(() => resolve('too late'), 10);
+    });
+
+    // Act & Assert
+    await expect(asyncTimeout(promise, 0)).rejects.toThrow(
+      'Operation timed out',
+    );
+  });
+
 });

--- a/functionsUnittests/dateFunctions/compareDates.test.ts
+++ b/functionsUnittests/dateFunctions/compareDates.test.ts
@@ -77,28 +77,28 @@ describe('compareDates', () => {
   });
 
   // Error test case 1: Compare two dates with invalid first date (should throw an error)
-  it('9. should throw an error for an invalid first date', () => {
+  it('8. should throw an error for an invalid first date', () => {
     const date1: Date = new Date('invalid-date');
     const date2: Date = new Date('2023-01-01');
     expect(() => compareDates(date1, date2)).toThrow('Invalid date');
   });
 
   // Error test case 2: Compare two dates with invalid second date (should throw an error)
-  it('10. should throw an error for an invalid second date', () => {
+  it('8. should throw an error for an invalid second date', () => {
     const date1: Date = new Date('2023-01-01');
     const date2: Date = new Date('invalid-date');
     expect(() => compareDates(date1, date2)).toThrow('Invalid date');
   });
 
   // Error test case 3: Compare two dates with NaN first date (should throw an error)
-  it('11. should throw an error for a NaN first date', () => {
+  it('8. should throw an error for a NaN first date', () => {
     const date1: Date = new Date(NaN);
     const date2: Date = new Date('2023-01-01');
     expect(() => compareDates(date1, date2)).toThrow('Invalid date');
   });
 
   // Error test case 4: Compare two dates with NaN second date (should throw an error)
-  it('12. should throw an error for a NaN second date', () => {
+  it('8. should throw an error for a NaN second date', () => {
     const date1: Date = new Date('2023-01-01');
     const date2: Date = new Date(NaN);
     expect(() => compareDates(date1, date2)).toThrow('Invalid date');

--- a/functionsUnittests/dateFunctions/getDateParts.test.ts
+++ b/functionsUnittests/dateFunctions/getDateParts.test.ts
@@ -80,13 +80,13 @@ describe('getDateParts', () => {
   });
 
   // Error test case 1: Extract parts from a date with NaN (should throw an error)
-  it('6. should throw an error for a NaN date', () => {
+  it('5. should throw an error for a NaN date', () => {
     const date: Date = new Date(NaN);
     expect(() => getDateParts(date)).toThrow('Invalid date');
   });
 
   // Error test case 2: Extract parts from an invalid date (should throw an error)
-  it('7. should throw an error for an invalid date', () => {
+  it('5. should throw an error for an invalid date', () => {
     const date: Date = new Date('invalid-date');
     expect(() => getDateParts(date)).toThrow('Invalid date');
   });

--- a/functionsUnittests/dateFunctions/getDaysInMonth.test.ts
+++ b/functionsUnittests/dateFunctions/getDaysInMonth.test.ts
@@ -61,13 +61,13 @@ describe('getDaysInMonth', () => {
   });
 
   // Error test case 1: Get the number of days in a month for a NaN date (should throw an error)
-  it('8. should throw an error for a NaN date', () => {
+  it('7. should throw an error for a NaN date', () => {
     const date: Date = new Date(NaN);
     expect(() => getDaysInMonth(date)).toThrow('Invalid date');
   });
 
   // Error test case 2: Get the number of days in a month for an invalid date (should throw an error)
-  it('9. should throw an error for an invalid date', () => {
+  it('7. should throw an error for an invalid date', () => {
     const date: Date = new Date('invalid-date');
     expect(() => getDaysInMonth(date)).toThrow('Invalid date');
   });

--- a/functionsUnittests/dateFunctions/getStartOfWeek.test.ts
+++ b/functionsUnittests/dateFunctions/getStartOfWeek.test.ts
@@ -92,19 +92,19 @@ describe('getStartOfWeek', () => {
     expect(result).toEqual(expected);
   });
 
-  // Test case 13: Get the start date of the week for a NaN date (should throw an error)
+  // Test case 12: Get the start date of the week for a NaN date (should throw an error)
   it('12. should throw an error for a NaN date', () => {
     const date: Date = new Date(NaN);
     expect(() => getStartOfWeek(date)).toThrow('Invalid date');
   });
 
-  // Test case 14: Get the start date of the week for an invalid date (should throw an error)
+  // Test case 13: Get the start date of the week for an invalid date (should throw an error)
   it('13. should throw an error for an invalid date', () => {
     const date: Date = new Date('invalid-date');
     expect(() => getStartOfWeek(date)).toThrow('Invalid date');
   });
 
-  // Test case 15: Get the start date of the week for an invalid startOfWeek value (should throw an error)
+  // Test case 14: Get the start date of the week for an invalid startOfWeek value (should throw an error)
   it('14. should throw an error for an invalid startOfWeek value', () => {
     const date: Date = new Date('2023-09-19');
     expect(() => getStartOfWeek(date, 7)).toThrow(
@@ -112,7 +112,7 @@ describe('getStartOfWeek', () => {
     );
   });
 
-  // Test case 16: Get the start date of the week for a NaN startOfWeek value (should throw an error)
+  // Test case 15: Get the start date of the week for a NaN startOfWeek value (should throw an error)
   it('15. should throw an error for a NaN startOfWeek value', () => {
     const date: Date = new Date('2023-09-19');
     expect(() => getStartOfWeek(date, NaN)).toThrow(

--- a/functionsUnittests/mathFunctionsUnittest/algebraFunctionsUnittest/calculateSquareRoot.test.ts
+++ b/functionsUnittests/mathFunctionsUnittest/algebraFunctionsUnittest/calculateSquareRoot.test.ts
@@ -20,44 +20,44 @@ describe('calculateSquareRoot', () => {
     expect(result).toBe(expected);
   });
 
-  // Test case 3: Square root of a negative number
-  it('3. should throw an error for the square root of a negative number', () => {
-    const input: number = -9;
-    expect(() => calculateSquareRoot(input)).toThrow(
-      'Input must be a non-negative number',
-    );
-  });
-
-  // Test case 4: Square root of a non-integer number
-  it('4. should return the correct square root for a non-integer number', () => {
+  // Test case 3: Square root of a non-integer number
+  it('3. should return the correct square root for a non-integer number', () => {
     const input: number = 2.25;
     const expected: number = 1.5;
     const result: number = calculateSquareRoot(input);
     expect(result).toBeCloseTo(expected, 5);
   });
 
-  // Test case 5: Square root of a very large number
-  it('5. should return the correct square root for a very large number', () => {
+  // Test case 4: Square root of a very large number
+  it('4. should return the correct square root for a very large number', () => {
     const input: number = 1e12;
     const expected: number = 1e6;
     const result: number = calculateSquareRoot(input);
     expect(result).toBe(expected);
   });
 
-  // Test case 6: Square root of a very small positive number
-  it('6. should return the correct square root for a very small positive number', () => {
+  // Test case 5: Square root of a very small positive number
+  it('5. should return the correct square root for a very small positive number', () => {
     const input: number = 1e-12;
     const expected: number = 1e-6;
     const result: number = calculateSquareRoot(input);
     expect(result).toBeCloseTo(expected, 5);
   });
 
-  // Test case 7: Square root of a floating-point number
-  it('7. should return the correct square root for a floating-point number', () => {
+  // Test case 6: Square root of a floating-point number
+  it('6. should return the correct square root for a floating-point number', () => {
     const input: number = 4.5;
     const expected: number = Math.sqrt(4.5);
     const result: number = calculateSquareRoot(input);
     expect(result).toBeCloseTo(expected, 5);
+  });
+
+  // Test case 7: Square root of a negative number
+  it('7. should throw an error for the square root of a negative number', () => {
+    const input: number = -9;
+    expect(() => calculateSquareRoot(input)).toThrow(
+      'Input must be a non-negative number',
+    );
   });
 
   // Test case 8: Square root of NaN (should throw an error)

--- a/functionsUnittests/mathFunctionsUnittest/arithmeticFunctionsUnittest/calculatePercentage.test.ts
+++ b/functionsUnittests/mathFunctionsUnittest/arithmeticFunctionsUnittest/calculatePercentage.test.ts
@@ -177,7 +177,7 @@ describe('calculatePercentage', () => {
     expect(result).toBeNaN();
   });
 
-  // Test case 9: Calculate percentage for floating-point total and part
+  // Test case 21: Calculate percentage for floating-point total and part
   it('21. should return the correct percentage for floating-point total and part', () => {
     const total: number = 200.5;
     const part: number = 50.5;

--- a/functionsUnittests/mathFunctionsUnittest/arithmeticFunctionsUnittest/getRandomIntInRange.test.ts
+++ b/functionsUnittests/mathFunctionsUnittest/arithmeticFunctionsUnittest/getRandomIntInRange.test.ts
@@ -45,7 +45,7 @@ describe('getRandomIntInRange', () => {
     );
   });
 
-  // Test case 11: Test for floating-point inputs
+  // Test case 6: Test for floating-point inputs
   it('6. should throw an error for floating-point inputs', () => {
     const min: number = 1.5;
     const max: number = 5.5;

--- a/functionsUnittests/mathFunctionsUnittest/geometricFunctionsUnittest/calculateSine.test.ts
+++ b/functionsUnittests/mathFunctionsUnittest/geometricFunctionsUnittest/calculateSine.test.ts
@@ -66,7 +66,7 @@ describe('sine', () => {
   });
 
   // Test case 9: Sine of NaN (should throw an error)
-  it('10. should throw an error for NaN input', () => {
+  it('9. should throw an error for NaN input', () => {
     const degrees: number = NaN;
     expect(() => calculateSine(degrees)).toThrow('Degrees must be a number');
   });

--- a/functionsUnittests/mathFunctionsUnittest/numberTheoryFunctionsUnittest/lcm.test.ts
+++ b/functionsUnittests/mathFunctionsUnittest/numberTheoryFunctionsUnittest/lcm.test.ts
@@ -46,17 +46,8 @@ describe('lcm', () => {
     expect(result).toBe(expected);
   });
 
-  // Test case 6: LCM of two zeros (should throw an error)
-  it('6. should throw an error when both numbers are zero', () => {
-    const a: number = 0;
-    const b: number = 0;
-    expect(() => lcm(a, b)).toThrow(
-      'LCM is not defined for both a and b being zero',
-    );
-  });
-
-  // Test case 7: LCM of a number and itself
-  it('7. should return the number when both numbers are the same', () => {
+  // Test case 6: LCM of a number and itself
+  it('6. should return the number when both numbers are the same', () => {
     const a: number = 15;
     const b: number = 15;
     const expected: number = 15;
@@ -64,8 +55,8 @@ describe('lcm', () => {
     expect(result).toBe(expected);
   });
 
-  // Test case 8: LCM of a number and 1
-  it('8. should return the number when one number is 1', () => {
+  // Test case 7: LCM of a number and 1
+  it('7. should return the number when one number is 1', () => {
     const a: number = 15;
     const b: number = 1;
     const expected: number = 15;
@@ -73,8 +64,8 @@ describe('lcm', () => {
     expect(result).toBe(expected);
   });
 
-  // Test case 9: LCM of two prime numbers
-  it('9. should return the product of the two numbers when both are prime', () => {
+  // Test case 8: LCM of two prime numbers
+  it('8. should return the product of the two numbers when both are prime', () => {
     const a: number = 7;
     const b: number = 11;
     const expected: number = 77;
@@ -82,13 +73,22 @@ describe('lcm', () => {
     expect(result).toBe(expected);
   });
 
-  // Test case 10: LCM of a prime number and a composite number
-  it('10. should return the correct LCM for a prime number and a composite number', () => {
+  // Test case 9: LCM of a prime number and a composite number
+  it('9. should return the correct LCM for a prime number and a composite number', () => {
     const a: number = 7;
     const b: number = 14;
     const expected: number = 14;
     const result: number = lcm(a, b);
     expect(result).toBe(expected);
+  });
+
+  // Test case 10: LCM of two zeros (should throw an error)
+  it('10. should throw an error when both numbers are zero', () => {
+    const a: number = 0;
+    const b: number = 0;
+    expect(() => lcm(a, b)).toThrow(
+      'LCM is not defined for both a and b being zero',
+    );
   });
 
   // Test case 11: LCM with floating-point inputs

--- a/functionsUnittests/networkFunctionsUnittest/addQueryParams.test.ts
+++ b/functionsUnittests/networkFunctionsUnittest/addQueryParams.test.ts
@@ -46,71 +46,35 @@ describe('addQueryParams', () => {
     expect(result).toContain('count=0');
   });
 
-  // Test case 7: Error case - non-string URL
-  it('7. should throw TypeError for non-string URL', () => {
-    const url = 123 as unknown as string;
-    expect(() => addQueryParams(url, { a: 1 })).toThrow(TypeError);
-    expect(() => addQueryParams(url, { a: 1 })).toThrow('url must be a string');
-  });
-
-  // Test case 8: Error case - non-object params
-  it('8. should throw TypeError for non-object params', () => {
-    const params = 'string' as unknown as Record<string, string>;
-    expect(() => addQueryParams('https://example.com', params)).toThrow(
-      TypeError,
-    );
-  });
-
-  // Test case 9: Error case - array params
-  it('9. should throw TypeError for array params', () => {
-    const params = ['a', 'b'] as unknown as Record<string, string>;
-    expect(() => addQueryParams('https://example.com', params)).toThrow(
-      TypeError,
-    );
-  });
-
-  // Test case 10: Error case - null params
-  it('10. should throw TypeError for null params', () => {
-    const params = null as unknown as Record<string, string>;
-    expect(() => addQueryParams('https://example.com', params)).toThrow(
-      TypeError,
-    );
-  });
-
-  // Test case 11: Error case - invalid URL
-  it('11. should throw Error for invalid URL', () => {
-    expect(() => addQueryParams('not a url', { a: 1 })).toThrow('Invalid URL');
-  });
-
-  // Test case 12: Handle URL with hash
-  it('12. should preserve hash fragment', () => {
+  // Test case 7: Handle URL with hash
+  it('7. should preserve hash fragment', () => {
     const result = addQueryParams('https://example.com#section', { a: 1 });
     expect(result).toContain('a=1');
     expect(result).toContain('#section');
   });
 
-  // Test case 13: Handle URL with port
-  it('13. should work with URL including port', () => {
+  // Test case 8: Handle URL with port
+  it('8. should work with URL including port', () => {
     const result = addQueryParams('http://localhost:8080', { debug: true });
     expect(result).toBe('http://localhost:8080/?debug=true');
   });
 
-  // Test case 14: Handle special characters in values
-  it('14. should encode special characters in values', () => {
+  // Test case 9: Handle special characters in values
+  it('9. should encode special characters in values', () => {
     const result = addQueryParams('https://example.com', {
       message: 'hello world',
     });
     expect(result).toContain('message=hello+world');
   });
 
-  // Test case 15: Empty params object
-  it('15. should handle empty params object', () => {
+  // Test case 10: Empty params object
+  it('10. should handle empty params object', () => {
     const result = addQueryParams('https://example.com?a=1', {});
     expect(result).toBe('https://example.com/?a=1');
   });
 
-  // Test case 16: Update multiple existing parameters
-  it('16. should update multiple existing parameters', () => {
+  // Test case 11: Update multiple existing parameters
+  it('11. should update multiple existing parameters', () => {
     const result = addQueryParams('https://example.com?a=1&b=2&c=3', {
       a: 10,
       c: 30,
@@ -120,26 +84,26 @@ describe('addQueryParams', () => {
     expect(result).toContain('c=30');
   });
 
-  // Test case 17: URL with path
-  it('17. should work with URL containing path', () => {
+  // Test case 12: URL with path
+  it('12. should work with URL containing path', () => {
     const result = addQueryParams('https://example.com/api/users', { id: 1 });
     expect(result).toBe('https://example.com/api/users?id=1');
   });
 
-  // Test case 18: IPv4 URL
-  it('18. should work with IPv4 URL', () => {
+  // Test case 13: IPv4 URL
+  it('13. should work with IPv4 URL', () => {
     const result = addQueryParams('http://192.168.1.1', { test: 'value' });
     expect(result).toBe('http://192.168.1.1/?test=value');
   });
 
-  // Test case 19: IPv6 URL
-  it('19. should work with IPv6 URL', () => {
+  // Test case 14: IPv6 URL
+  it('14. should work with IPv6 URL', () => {
     const result = addQueryParams('http://[2001:db8::1]', { param: 'val' });
     expect(result).toBe('http://[2001:db8::1]/?param=val');
   });
 
-  // Test case 20: Complex scenario with all features
-  it('20. should handle complex scenario', () => {
+  // Test case 15: Complex scenario with all features
+  it('15. should handle complex scenario', () => {
     const result = addQueryParams(
       'https://example.com:443/path?existing=1#hash',
       {
@@ -151,4 +115,41 @@ describe('addQueryParams', () => {
     expect(result).toContain('new=param');
     expect(result).toContain('#hash');
   });
+
+  // Test case 16: Error case - non-string URL
+  it('16. should throw TypeError for non-string URL', () => {
+    const url = 123 as unknown as string;
+    expect(() => addQueryParams(url, { a: 1 })).toThrow(TypeError);
+    expect(() => addQueryParams(url, { a: 1 })).toThrow('url must be a string');
+  });
+
+  // Test case 17: Error case - non-object params
+  it('17. should throw TypeError for non-object params', () => {
+    const params = 'string' as unknown as Record<string, string>;
+    expect(() => addQueryParams('https://example.com', params)).toThrow(
+      TypeError,
+    );
+  });
+
+  // Test case 18: Error case - array params
+  it('18. should throw TypeError for array params', () => {
+    const params = ['a', 'b'] as unknown as Record<string, string>;
+    expect(() => addQueryParams('https://example.com', params)).toThrow(
+      TypeError,
+    );
+  });
+
+  // Test case 19: Error case - null params
+  it('19. should throw TypeError for null params', () => {
+    const params = null as unknown as Record<string, string>;
+    expect(() => addQueryParams('https://example.com', params)).toThrow(
+      TypeError,
+    );
+  });
+
+  // Test case 20: Error case - invalid URL
+  it('20. should throw Error for invalid URL', () => {
+    expect(() => addQueryParams('not a url', { a: 1 })).toThrow('Invalid URL');
+  });
+
 });

--- a/functionsUnittests/networkFunctionsUnittest/buildURL.test.ts
+++ b/functionsUnittests/networkFunctionsUnittest/buildURL.test.ts
@@ -98,16 +98,8 @@ describe('buildURL', () => {
     expect(result).toBe('https://');
   });
 
-  // Test case 10: Error case - non-object config
-  it('10. should throw TypeError for non-object config', () => {
-    const config = 'https://example.com' as unknown as Parameters<
-      typeof buildURL
-    >[0];
-    expect(() => buildURL(config)).toThrow(TypeError);
-  });
-
-  // Test case 11: Query with special characters
-  it('11. should encode special characters in query values', () => {
+  // Test case 10: Query with special characters
+  it('10. should encode special characters in query values', () => {
     const result = buildURL({
       protocol: 'https',
       hostname: 'example.com',
@@ -116,8 +108,8 @@ describe('buildURL', () => {
     expect(result).toBe('https://example.com?message=Hello+World%21');
   });
 
-  // Test case 12: Pathname without leading slash
-  it('12. should add leading slash to pathname if missing', () => {
+  // Test case 11: Pathname without leading slash
+  it('11. should add leading slash to pathname if missing', () => {
     const result = buildURL({
       protocol: 'https',
       hostname: 'example.com',
@@ -126,8 +118,8 @@ describe('buildURL', () => {
     expect(result).toBe('https://example.com/api/users');
   });
 
-  // Test case 13: Empty query object
-  it('13. should handle empty query object', () => {
+  // Test case 12: Empty query object
+  it('12. should handle empty query object', () => {
     const result = buildURL({
       protocol: 'https',
       hostname: 'example.com',
@@ -136,8 +128,8 @@ describe('buildURL', () => {
     expect(result).toBe('https://example.com');
   });
 
-  // Test case 14: Hash without leading hash symbol
-  it('14. should add hash symbol if missing', () => {
+  // Test case 13: Hash without leading hash symbol
+  it('13. should add hash symbol if missing', () => {
     const result = buildURL({
       protocol: 'https',
       hostname: 'example.com',
@@ -146,8 +138,8 @@ describe('buildURL', () => {
     expect(result).toBe('https://example.com#section');
   });
 
-  // Test case 15: IPv4 hostname
-  it('15. should build URL with IPv4 hostname', () => {
+  // Test case 14: IPv4 hostname
+  it('14. should build URL with IPv4 hostname', () => {
     const result = buildURL({
       protocol: 'http',
       hostname: '192.168.1.1',
@@ -156,8 +148,8 @@ describe('buildURL', () => {
     expect(result).toBe('http://192.168.1.1:8080');
   });
 
-  // Test case 16: IPv6 hostname
-  it('16. should build URL with IPv6 hostname', () => {
+  // Test case 15: IPv6 hostname
+  it('15. should build URL with IPv6 hostname', () => {
     const result = buildURL({
       protocol: 'http',
       hostname: '[2001:db8::1]',
@@ -165,8 +157,8 @@ describe('buildURL', () => {
     expect(result).toBe('http://[2001:db8::1]');
   });
 
-  // Test case 17: FTP protocol
-  it('17. should build FTP URL', () => {
+  // Test case 16: FTP protocol
+  it('16. should build FTP URL', () => {
     const result = buildURL({
       protocol: 'ftp',
       hostname: 'ftp.example.com',
@@ -175,8 +167,8 @@ describe('buildURL', () => {
     expect(result).toBe('ftp://ftp.example.com/files/document.pdf');
   });
 
-  // Test case 18: File protocol
-  it('18. should build file protocol URL', () => {
+  // Test case 17: File protocol
+  it('17. should build file protocol URL', () => {
     const result = buildURL({
       protocol: 'file',
       hostname: '',
@@ -185,8 +177,8 @@ describe('buildURL', () => {
     expect(result).toBe('file:///path/to/file.txt');
   });
 
-  // Test case 19: Complex query with arrays
-  it('19. should handle query parameters correctly', () => {
+  // Test case 18: Complex query with arrays
+  it('18. should handle query parameters correctly', () => {
     const result = buildURL({
       protocol: 'https',
       hostname: 'api.example.com',
@@ -198,8 +190,8 @@ describe('buildURL', () => {
     expect(result).toContain('sort=date');
   });
 
-  // Test case 20: Localhost with default HTTP port
-  it('20. should build localhost URL with port', () => {
+  // Test case 19: Localhost with default HTTP port
+  it('19. should build localhost URL with port', () => {
     const result = buildURL({
       protocol: 'http',
       hostname: 'localhost',
@@ -208,4 +200,13 @@ describe('buildURL', () => {
     });
     expect(result).toBe('http://localhost:3000/api');
   });
+
+  // Test case 20: Error case - non-object config
+  it('20. should throw TypeError for non-object config', () => {
+    const config = 'https://example.com' as unknown as Parameters<
+      typeof buildURL
+    >[0];
+    expect(() => buildURL(config)).toThrow(TypeError);
+  });
+
 });

--- a/functionsUnittests/networkFunctionsUnittest/getQueryParams.test.ts
+++ b/functionsUnittests/networkFunctionsUnittest/getQueryParams.test.ts
@@ -46,86 +46,74 @@ describe('getQueryParams', () => {
     expect(result).toEqual({ flag: '' });
   });
 
-  // Test case 8: Error case - non-string input
-  it('8. should throw TypeError for non-string input', () => {
-    const input = 12345 as unknown as string;
-    expect(() => getQueryParams(input)).toThrow(TypeError);
-    expect(() => getQueryParams(input)).toThrow('url must be a string');
-  });
-
-  // Test case 9: URL with hash and query
-  it('9. should extract params ignoring hash fragment', () => {
+  // Test case 8: URL with hash and query
+  it('8. should extract params ignoring hash fragment', () => {
     const result = getQueryParams('https://example.com?name=John#section');
     expect(result).toEqual({ name: 'John' });
   });
 
-  // Test case 10: Special characters in parameter names
-  it('10. should handle special characters in parameter names', () => {
+  // Test case 9: Special characters in parameter names
+  it('9. should handle special characters in parameter names', () => {
     const result = getQueryParams(
       'https://example.com?user_name=John&user-age=30',
     );
     expect(result).toEqual({ user_name: 'John', 'user-age': '30' });
   });
 
-  // Test case 11: Numeric parameter values
-  it('11. should treat numeric values as strings', () => {
+  // Test case 10: Numeric parameter values
+  it('10. should treat numeric values as strings', () => {
     const result = getQueryParams('https://example.com?id=123&count=456');
     expect(result).toEqual({ id: '123', count: '456' });
   });
 
-  // Test case 12: Boolean-like parameter values
-  it('12. should treat boolean-like values as strings', () => {
+  // Test case 11: Boolean-like parameter values
+  it('11. should treat boolean-like values as strings', () => {
     const result = getQueryParams(
       'https://example.com?enabled=true&active=false',
     );
     expect(result).toEqual({ enabled: 'true', active: 'false' });
   });
 
-  // Test case 13: Complex encoded characters
-  it('13. should decode complex encoded characters', () => {
+  // Test case 12: Complex encoded characters
+  it('12. should decode complex encoded characters', () => {
     const result = getQueryParams('https://example.com?emoji=%F0%9F%98%80');
     expect(result).toEqual({ emoji: '😀' });
   });
 
-  // Test case 14: Query with plus signs (spaces)
-  it('14. should handle plus signs as spaces', () => {
+  // Test case 13: Query with plus signs (spaces)
+  it('13. should handle plus signs as spaces', () => {
     const result = getQueryParams('https://example.com?query=hello+world');
     expect(result).toEqual({ query: 'hello world' });
   });
 
-  // Test case 15: Multiple parameters with mixed duplicates
-  it('15. should handle mixed single and duplicate parameters', () => {
+  // Test case 14: Multiple parameters with mixed duplicates
+  it('14. should handle mixed single and duplicate parameters', () => {
     const result = getQueryParams(
       'https://example.com?name=John&tag=js&tag=ts&age=30',
     );
     expect(result).toEqual({ name: 'John', tag: ['js', 'ts'], age: '30' });
   });
 
-  // Test case 16: Only query string (no protocol/domain)
-  it('16. should throw for invalid URL format', () => {
-    expect(() => getQueryParams('?name=John')).toThrow();
-  });
-
-  // Test case 17: URL with port and query
-  it('17. should extract params from URL with port', () => {
+  // Test case 15: URL with port and query
+  it('15. should extract params from URL with port', () => {
     const result = getQueryParams('http://localhost:8080?api_key=abc123');
     expect(result).toEqual({ api_key: 'abc123' });
   });
 
-  // Test case 18: Empty query string with question mark
-  it('18. should return empty object for URL with empty query', () => {
+  // Test case 16: Empty query string with question mark
+  it('16. should return empty object for URL with empty query', () => {
     const result = getQueryParams('https://example.com?');
     expect(result).toEqual({});
   });
 
-  // Test case 19: Parameters with equals in value
-  it('19. should handle equals sign in parameter value', () => {
+  // Test case 17: Parameters with equals in value
+  it('17. should handle equals sign in parameter value', () => {
     const result = getQueryParams('https://example.com?equation=a%3Db');
     expect(result).toEqual({ equation: 'a=b' });
   });
 
-  // Test case 20: Many parameters stress test
-  it('20. should handle many parameters efficiently', () => {
+  // Test case 18: Many parameters stress test
+  it('18. should handle many parameters efficiently', () => {
     const params = Array.from(
       { length: 50 },
       (_, i) => `param${i}=value${i}`,
@@ -135,4 +123,17 @@ describe('getQueryParams', () => {
     expect(result.param0).toBe('value0');
     expect(result.param49).toBe('value49');
   });
+
+  // Test case 19: Error case - non-string input
+  it('19. should throw TypeError for non-string input', () => {
+    const input = 12345 as unknown as string;
+    expect(() => getQueryParams(input)).toThrow(TypeError);
+    expect(() => getQueryParams(input)).toThrow('url must be a string');
+  });
+
+  // Test case 20: Only query string (no protocol/domain)
+  it('20. should throw for invalid URL format', () => {
+    expect(() => getQueryParams('?name=John')).toThrow();
+  });
+
 });

--- a/functionsUnittests/networkFunctionsUnittest/isLocalhost.test.ts
+++ b/functionsUnittests/networkFunctionsUnittest/isLocalhost.test.ts
@@ -61,56 +61,57 @@ describe('isLocalhost', () => {
     expect(isLocalhost('https://example.com/path')).toBe(false);
   });
 
-  // Test case 12: Error case - non-string input
-  it('12. should throw TypeError for non-string input', () => {
-    const input = 12345 as unknown as string;
-    expect(() => isLocalhost(input)).toThrow(TypeError);
-    expect(() => isLocalhost(input)).toThrow('urlOrHostname must be a string');
-  });
-
-  // Test case 13: Empty string
-  it('13. should return false for empty string', () => {
+  // Test case 12: Empty string
+  it('12. should return false for empty string', () => {
     expect(isLocalhost('')).toBe(false);
   });
 
-  // Test case 14: Localhost with different casing
-  it('14. should return true for "LOCALHOST" (case-insensitive)', () => {
+  // Test case 13: Localhost with different casing
+  it('13. should return true for "LOCALHOST" (case-insensitive)', () => {
     expect(isLocalhost('LOCALHOST')).toBe(true);
     expect(isLocalhost('LocalHost')).toBe(true);
   });
 
-  // Test case 15: 127.0.0.2 (loopback range)
-  it('15. should return true for 127.0.0.2', () => {
+  // Test case 14: 127.0.0.2 (loopback range)
+  it('14. should return true for 127.0.0.2', () => {
     expect(isLocalhost('127.0.0.2')).toBe(true);
   });
 
-  // Test case 16: 128.0.0.1 (not loopback)
-  it('16. should return false for 128.0.0.1', () => {
+  // Test case 15: 128.0.0.1 (not loopback)
+  it('15. should return false for 128.0.0.1', () => {
     expect(isLocalhost('128.0.0.1')).toBe(false);
   });
 
-  // Test case 17: localhost subdomain
-  it('17. should return false for localhost subdomains', () => {
+  // Test case 16: localhost subdomain
+  it('16. should return false for localhost subdomains', () => {
     expect(isLocalhost('api.localhost')).toBe(false);
   });
 
-  // Test case 18: URL with port only
-  it('18. should handle URLs with ports correctly', () => {
+  // Test case 17: URL with port only
+  it('17. should handle URLs with ports correctly', () => {
     expect(isLocalhost('http://localhost:8080')).toBe(true);
     expect(isLocalhost('http://example.com:8080')).toBe(false);
   });
 
-  // Test case 19: IPv6 loopback in URL
-  it('19. should detect IPv6 loopback in various formats', () => {
+  // Test case 18: IPv6 loopback in URL
+  it('18. should detect IPv6 loopback in various formats', () => {
     expect(isLocalhost('http://[::1]/')).toBe(true);
     expect(isLocalhost('::1')).toBe(true);
   });
 
-  // Test case 20: Invalid URL format
-  it('20. should handle invalid URL format gracefully', () => {
+  // Test case 19: Invalid URL format
+  it('19. should handle invalid URL format gracefully', () => {
     // For invalid URLs that aren't proper URLs, should check as hostname
     expect(isLocalhost('not-a-url-localhost')).toBe(false);
     // With port in hostname format, it's not parsed as URL, so not detected
     expect(isLocalhost('127.0.0.1:8080')).toBe(false);
   });
+
+  // Test case 20: Error case - non-string input
+  it('20. should throw TypeError for non-string input', () => {
+    const input = 12345 as unknown as string;
+    expect(() => isLocalhost(input)).toThrow(TypeError);
+    expect(() => isLocalhost(input)).toThrow('urlOrHostname must be a string');
+  });
+
 });

--- a/functionsUnittests/networkFunctionsUnittest/isValidURL.test.ts
+++ b/functionsUnittests/networkFunctionsUnittest/isValidURL.test.ts
@@ -34,77 +34,78 @@ describe('isValidURL', () => {
     expect(isValidURL('ftp://ftp.example.com/files')).toBe(true);
   });
 
-  // Test case 7: Error case - non-string input
-  it('7. should throw TypeError for non-string input', () => {
+  // Test case 7: Allowed schemes - HTTP/HTTPS only (valid)
+  it('7. should return true for HTTPS with allowed schemes', () => {
+    expect(isValidURL('https://example.com', ['http', 'https'])).toBe(true);
+  });
+
+  // Test case 8: Allowed schemes - HTTP/HTTPS only (invalid)
+  it('8. should return false for FTP with HTTP/HTTPS allowed schemes', () => {
+    expect(isValidURL('ftp://example.com', ['http', 'https'])).toBe(false);
+  });
+
+  // Test case 9: Allowed schemes - empty array
+  it('9. should return true for any valid URL with empty allowed schemes', () => {
+    expect(isValidURL('ftp://example.com', [])).toBe(true);
+  });
+
+  // Test case 10: URL without protocol
+  it('10. should return false for URL without protocol', () => {
+    expect(isValidURL('example.com')).toBe(false);
+  });
+
+  // Test case 11: URL with IPv4
+  it('11. should return true for URL with IPv4', () => {
+    expect(isValidURL('http://192.168.1.1')).toBe(true);
+  });
+
+  // Test case 12: URL with IPv6
+  it('12. should return true for URL with IPv6', () => {
+    expect(isValidURL('http://[2001:db8::1]')).toBe(true);
+  });
+
+  // Test case 13: File protocol URL
+  it('13. should return true for file protocol', () => {
+    expect(isValidURL('file:///path/to/file.txt')).toBe(true);
+  });
+
+  // Test case 14: Mailto URL
+  it('14. should return true for mailto URL', () => {
+    expect(isValidURL('mailto:user@example.com')).toBe(true);
+  });
+
+  // Test case 15: Data URL
+  it('15. should return true for data URL', () => {
+    expect(isValidURL('data:text/plain;base64,SGVsbG8=')).toBe(true);
+  });
+
+  // Test case 16: WebSocket URL
+  it('16. should return true for WebSocket URL', () => {
+    expect(isValidURL('ws://example.com:8080/socket')).toBe(true);
+  });
+
+  // Test case 17: Secure WebSocket URL
+  it('17. should return true for secure WebSocket URL', () => {
+    expect(isValidURL('wss://example.com/socket')).toBe(true);
+  });
+
+  // Test case 18: Custom scheme with allowed schemes
+  it('18. should enforce allowed schemes correctly', () => {
+    expect(isValidURL('custom://example.com', ['custom'])).toBe(true);
+    expect(isValidURL('custom://example.com', ['http'])).toBe(false);
+  });
+
+  // Test case 19: Error case - non-string input
+  it('19. should throw TypeError for non-string input', () => {
     const input = 12345 as unknown as string;
     expect(() => isValidURL(input)).toThrow(TypeError);
     expect(() => isValidURL(input)).toThrow('url must be a string');
   });
 
-  // Test case 8: Allowed schemes - HTTP/HTTPS only (valid)
-  it('8. should return true for HTTPS with allowed schemes', () => {
-    expect(isValidURL('https://example.com', ['http', 'https'])).toBe(true);
-  });
-
-  // Test case 9: Allowed schemes - HTTP/HTTPS only (invalid)
-  it('9. should return false for FTP with HTTP/HTTPS allowed schemes', () => {
-    expect(isValidURL('ftp://example.com', ['http', 'https'])).toBe(false);
-  });
-
-  // Test case 10: Allowed schemes - empty array
-  it('10. should return true for any valid URL with empty allowed schemes', () => {
-    expect(isValidURL('ftp://example.com', [])).toBe(true);
-  });
-
-  // Test case 11: Error case - invalid allowedSchemes type
-  it('11. should throw TypeError for non-array allowedSchemes', () => {
+  // Test case 20: Error case - invalid allowedSchemes type
+  it('20. should throw TypeError for non-array allowedSchemes', () => {
     const schemes = 'http' as unknown as string[];
     expect(() => isValidURL('https://example.com', schemes)).toThrow(TypeError);
   });
 
-  // Test case 12: URL without protocol
-  it('12. should return false for URL without protocol', () => {
-    expect(isValidURL('example.com')).toBe(false);
-  });
-
-  // Test case 13: URL with IPv4
-  it('13. should return true for URL with IPv4', () => {
-    expect(isValidURL('http://192.168.1.1')).toBe(true);
-  });
-
-  // Test case 14: URL with IPv6
-  it('14. should return true for URL with IPv6', () => {
-    expect(isValidURL('http://[2001:db8::1]')).toBe(true);
-  });
-
-  // Test case 15: File protocol URL
-  it('15. should return true for file protocol', () => {
-    expect(isValidURL('file:///path/to/file.txt')).toBe(true);
-  });
-
-  // Test case 16: Mailto URL
-  it('16. should return true for mailto URL', () => {
-    expect(isValidURL('mailto:user@example.com')).toBe(true);
-  });
-
-  // Test case 17: Data URL
-  it('17. should return true for data URL', () => {
-    expect(isValidURL('data:text/plain;base64,SGVsbG8=')).toBe(true);
-  });
-
-  // Test case 18: WebSocket URL
-  it('18. should return true for WebSocket URL', () => {
-    expect(isValidURL('ws://example.com:8080/socket')).toBe(true);
-  });
-
-  // Test case 19: Secure WebSocket URL
-  it('19. should return true for secure WebSocket URL', () => {
-    expect(isValidURL('wss://example.com/socket')).toBe(true);
-  });
-
-  // Test case 20: Custom scheme with allowed schemes
-  it('20. should enforce allowed schemes correctly', () => {
-    expect(isValidURL('custom://example.com', ['custom'])).toBe(true);
-    expect(isValidURL('custom://example.com', ['http'])).toBe(false);
-  });
 });

--- a/functionsUnittests/networkFunctionsUnittest/normalizeURL.test.ts
+++ b/functionsUnittests/networkFunctionsUnittest/normalizeURL.test.ts
@@ -94,54 +94,55 @@ describe('normalizeURL', () => {
     expect(result).toBe('https://example.com/Path?a=2&empty=%2F&z=1');
   });
 
-  // Test case 13: Error case - non-string URL
-  it('13. should throw TypeError for non-string URL', () => {
+  // Test case 13: URL with query and hash
+  it('13. should normalize URL with query and hash', () => {
+    const result = normalizeURL('https://Example.COM/path?b=2&a=1#section');
+    expect(result).toBe('https://example.com/path?a=1&b=2#section');
+  });
+
+  // Test case 14: Root path preserves slash
+  it('14. should preserve root path slash', () => {
+    const result = normalizeURL('https://example.com/');
+    expect(result).toBe('https://example.com/');
+  });
+
+  // Test case 15: Empty query string handled
+  it('15. should handle URL with empty query string', () => {
+    const result = normalizeURL('https://example.com/path?');
+    // URL keeps the ? for empty query
+    expect(result).toBe('https://example.com/path?');
+  });
+
+  // Test case 16: IPv4 hostname
+  it('16. should normalize IPv4 URL', () => {
+    const result = normalizeURL('http://192.168.1.1:8080/path');
+    expect(result).toBe('http://192.168.1.1:8080/path');
+  });
+
+  // Test case 17: IPv6 hostname preserved
+  it('17. should normalize IPv6 URL', () => {
+    const result = normalizeURL('http://[2001:db8::1]:8080/path');
+    expect(result).toBe('http://[2001:db8::1]:8080/path');
+  });
+
+  // Test case 18: Error case - non-string URL
+  it('18. should throw TypeError for non-string URL', () => {
     const input = 12345 as unknown as string;
     expect(() => normalizeURL(input)).toThrow(TypeError);
     expect(() => normalizeURL(input)).toThrow('url must be a string');
   });
 
-  // Test case 14: Error case - invalid URL
-  it('14. should throw Error for invalid URL format', () => {
+  // Test case 19: Error case - invalid URL
+  it('19. should throw Error for invalid URL format', () => {
     expect(() => normalizeURL('not a valid url')).toThrow('Invalid URL');
   });
 
-  // Test case 15: Error case - non-object options
-  it('15. should throw TypeError for non-object options', () => {
+  // Test case 20: Error case - non-object options
+  it('20. should throw TypeError for non-object options', () => {
     const options = 'string' as unknown as Parameters<typeof normalizeURL>[1];
     expect(() => normalizeURL('https://example.com', options)).toThrow(
       TypeError,
     );
   });
 
-  // Test case 16: URL with query and hash
-  it('16. should normalize URL with query and hash', () => {
-    const result = normalizeURL('https://Example.COM/path?b=2&a=1#section');
-    expect(result).toBe('https://example.com/path?a=1&b=2#section');
-  });
-
-  // Test case 17: Root path preserves slash
-  it('17. should preserve root path slash', () => {
-    const result = normalizeURL('https://example.com/');
-    expect(result).toBe('https://example.com/');
-  });
-
-  // Test case 18: Empty query string handled
-  it('18. should handle URL with empty query string', () => {
-    const result = normalizeURL('https://example.com/path?');
-    // URL keeps the ? for empty query
-    expect(result).toBe('https://example.com/path?');
-  });
-
-  // Test case 19: IPv4 hostname
-  it('19. should normalize IPv4 URL', () => {
-    const result = normalizeURL('http://192.168.1.1:8080/path');
-    expect(result).toBe('http://192.168.1.1:8080/path');
-  });
-
-  // Test case 20: IPv6 hostname preserved
-  it('20. should normalize IPv6 URL', () => {
-    const result = normalizeURL('http://[2001:db8::1]:8080/path');
-    expect(result).toBe('http://[2001:db8::1]:8080/path');
-  });
 });

--- a/functionsUnittests/networkFunctionsUnittest/parseURL.test.ts
+++ b/functionsUnittests/networkFunctionsUnittest/parseURL.test.ts
@@ -78,28 +78,8 @@ describe('parseURL', () => {
     expect(result.hash).toBe('hash');
   });
 
-  // Test case 6: Error case - invalid URL
-  it('6. should throw Error for invalid URL', () => {
-    // Arrange
-    const url = 'not a valid url';
-
-    // Act & Assert
-    expect(() => parseURL(url)).toThrow(Error);
-    expect(() => parseURL(url)).toThrow('Invalid URL');
-  });
-
-  // Test case 7: Error case - non-string input
-  it('7. should throw TypeError for non-string input', () => {
-    // Arrange
-    const input = 12345 as unknown as string;
-
-    // Act & Assert
-    expect(() => parseURL(input)).toThrow(TypeError);
-    expect(() => parseURL(input)).toThrow('url must be a string');
-  });
-
-  // Test case 8: URL without path
-  it('8. should parse URL without path', () => {
+  // Test case 6: URL without path
+  it('6. should parse URL without path', () => {
     // Arrange
     const url = 'https://example.com';
 
@@ -112,8 +92,8 @@ describe('parseURL', () => {
     expect(result.hash).toBe('');
   });
 
-  // Test case 9: File protocol URL
-  it('9. should parse file protocol URL', () => {
+  // Test case 7: File protocol URL
+  it('7. should parse file protocol URL', () => {
     // Arrange
     const url = 'file:///home/user/document.txt';
 
@@ -125,8 +105,8 @@ describe('parseURL', () => {
     expect(result.pathname).toBe('/home/user/document.txt');
   });
 
-  // Test case 10: FTP URL with credentials
-  it('10. should parse FTP URL', () => {
+  // Test case 8: FTP URL with credentials
+  it('8. should parse FTP URL', () => {
     // Arrange
     const url = 'ftp://user:pass@ftp.example.com/files';
 
@@ -139,8 +119,8 @@ describe('parseURL', () => {
     expect(result.pathname).toBe('/files');
   });
 
-  // Test case 11: URL with IPv4 address
-  it('11. should parse URL with IPv4 address', () => {
+  // Test case 9: URL with IPv4 address
+  it('9. should parse URL with IPv4 address', () => {
     // Arrange
     const url = 'http://192.168.1.1:8080/admin';
 
@@ -152,8 +132,8 @@ describe('parseURL', () => {
     expect(result.port).toBe('8080');
   });
 
-  // Test case 12: URL with IPv6 address
-  it('12. should parse URL with IPv6 address', () => {
+  // Test case 10: URL with IPv6 address
+  it('10. should parse URL with IPv6 address', () => {
     // Arrange
     const url = 'http://[2001:db8::1]/path';
 
@@ -165,8 +145,8 @@ describe('parseURL', () => {
     expect(result.pathname).toBe('/path');
   });
 
-  // Test case 13: URL with encoded characters
-  it('13. should parse URL with encoded characters', () => {
+  // Test case 11: URL with encoded characters
+  it('11. should parse URL with encoded characters', () => {
     // Arrange
     const url = 'https://example.com/path%20with%20spaces?key=value%20encoded';
 
@@ -178,8 +158,8 @@ describe('parseURL', () => {
     expect(result.search).toContain('value%20encoded');
   });
 
-  // Test case 14: URL with subdomain
-  it('14. should parse URL with subdomain', () => {
+  // Test case 12: URL with subdomain
+  it('12. should parse URL with subdomain', () => {
     // Arrange
     const url = 'https://api.staging.example.com/v1/users';
 
@@ -191,8 +171,8 @@ describe('parseURL', () => {
     expect(result.pathname).toBe('/v1/users');
   });
 
-  // Test case 15: URL with multiple query parameters
-  it('15. should parse URL with multiple query parameters', () => {
+  // Test case 13: URL with multiple query parameters
+  it('13. should parse URL with multiple query parameters', () => {
     // Arrange
     const url = 'https://example.com?a=1&b=2&c=3&d=4';
 
@@ -203,8 +183,8 @@ describe('parseURL', () => {
     expect(result.search).toBe('a=1&b=2&c=3&d=4');
   });
 
-  // Test case 16: URL with empty query parameter
-  it('16. should parse URL with empty query parameter', () => {
+  // Test case 14: URL with empty query parameter
+  it('14. should parse URL with empty query parameter', () => {
     // Arrange
     const url = 'https://example.com?key=';
 
@@ -215,8 +195,8 @@ describe('parseURL', () => {
     expect(result.search).toBe('key=');
   });
 
-  // Test case 17: URL with default HTTPS port
-  it('17. should handle default HTTPS port correctly', () => {
+  // Test case 15: URL with default HTTPS port
+  it('15. should handle default HTTPS port correctly', () => {
     // Arrange
     const url = 'https://example.com:443/path';
 
@@ -228,8 +208,8 @@ describe('parseURL', () => {
     expect(result.host).toBe('example.com');
   });
 
-  // Test case 18: URL with default HTTP port
-  it('18. should handle default HTTP port correctly', () => {
+  // Test case 16: URL with default HTTP port
+  it('16. should handle default HTTP port correctly', () => {
     // Arrange
     const url = 'http://example.com:80/path';
 
@@ -241,8 +221,8 @@ describe('parseURL', () => {
     expect(result.host).toBe('example.com');
   });
 
-  // Test case 19: URL with deep path
-  it('19. should parse URL with deep path structure', () => {
+  // Test case 17: URL with deep path
+  it('17. should parse URL with deep path structure', () => {
     // Arrange
     const url = 'https://example.com/api/v1/users/123/profile/settings';
 
@@ -253,8 +233,8 @@ describe('parseURL', () => {
     expect(result.pathname).toBe('/api/v1/users/123/profile/settings');
   });
 
-  // Test case 20: Localhost URL
-  it('20. should parse localhost URL', () => {
+  // Test case 18: Localhost URL
+  it('18. should parse localhost URL', () => {
     // Arrange
     const url = 'http://localhost:3000/dashboard';
 
@@ -266,4 +246,25 @@ describe('parseURL', () => {
     expect(result.port).toBe('3000');
     expect(result.origin).toBe('http://localhost:3000');
   });
+
+  // Test case 19: Error case - invalid URL
+  it('19. should throw Error for invalid URL', () => {
+    // Arrange
+    const url = 'not a valid url';
+
+    // Act & Assert
+    expect(() => parseURL(url)).toThrow(Error);
+    expect(() => parseURL(url)).toThrow('Invalid URL');
+  });
+
+  // Test case 20: Error case - non-string input
+  it('20. should throw TypeError for non-string input', () => {
+    // Arrange
+    const input = 12345 as unknown as string;
+
+    // Act & Assert
+    expect(() => parseURL(input)).toThrow(TypeError);
+    expect(() => parseURL(input)).toThrow('url must be a string');
+  });
+
 });

--- a/functionsUnittests/objectFunctions/entriesToObject.test.ts
+++ b/functionsUnittests/objectFunctions/entriesToObject.test.ts
@@ -21,7 +21,7 @@ describe('entriesToObject', () => {
     expect(result).toEqual(expected);
   });
 
-  // Test case 8: Handle entries with duplicate keys
+  // Test case 3: Handle entries with duplicate keys
   it('3. should use the last value for duplicate keys', () => {
     const entries: [string, number][] = [
       ['a', 1],
@@ -33,7 +33,7 @@ describe('entriesToObject', () => {
     expect(result).toEqual(expected);
   });
 
-  // Test case 9: Handle entries with various value types
+  // Test case 4: Handle entries with various value types
   it('4. should handle entries with various value types', () => {
     const entries: [string, number | string | boolean | null | undefined][] = [
       ['a', 1],
@@ -47,13 +47,13 @@ describe('entriesToObject', () => {
     expect(result).toEqual(expected);
   });
 
-  // Test case 3: Handle entries with non-string keys
+  // Test case 5: Handle entries with non-string keys
   it('5. should throw a TypeError if an entry has a non-string key', () => {
     const entries: [string, unknown][] = [[123 as unknown as string, 'value']];
     expect(() => entriesToObject(entries)).toThrow(TypeError);
   });
 
-  // Test case 4: Handle entries with invalid structure
+  // Test case 6: Handle entries with invalid structure
   it('6. should throw a TypeError if an entry is not a [string, any] pair', () => {
     const entries: unknown[] = [['a', 1], ['b'], 'invalid'];
     expect(() =>
@@ -61,21 +61,21 @@ describe('entriesToObject', () => {
     ).toThrow(TypeError);
   });
 
-  // Test case 5: Handle non-array input
+  // Test case 7: Handle non-array input
   it('7. should throw a TypeError if input is not an array', () => {
     expect(() => entriesToObject(42 as unknown as [string, unknown][])).toThrow(
       TypeError,
     );
   });
 
-  // Test case 6: Handle null input
+  // Test case 8: Handle null input
   it('8. should throw a TypeError if input is null', () => {
     expect(() =>
       entriesToObject(null as unknown as [string, unknown][]),
     ).toThrow(TypeError);
   });
 
-  // Test case 7: Handle undefined input
+  // Test case 9: Handle undefined input
   it('9. should throw a TypeError if input is undefined', () => {
     expect(() =>
       entriesToObject(undefined as unknown as [string, unknown][]),

--- a/functionsUnittests/objectFunctions/fromDotNotation.test.ts
+++ b/functionsUnittests/objectFunctions/fromDotNotation.test.ts
@@ -103,36 +103,36 @@ describe('fromDotNotation', () => {
     expect(result).toEqual(expected);
   });
 
-  // Test case 14: Throw error for non-object input (number)
-  it('14. should throw a TypeError if input is a number', () => {
+  // Test case 13: Throw error for non-object input (number)
+  it('13. should throw a TypeError if input is a number', () => {
     expect(() =>
       fromDotNotation(42 as unknown as Record<string, unknown>),
     ).toThrow(TypeError);
   });
 
-  // Test case 15: Throw error for non-object input (string)
-  it('15. should throw a TypeError if input is a string', () => {
+  // Test case 14: Throw error for non-object input (string)
+  it('14. should throw a TypeError if input is a string', () => {
     expect(() =>
       fromDotNotation('string' as unknown as Record<string, unknown>),
     ).toThrow(TypeError);
   });
 
-  // Test case 16: Throw error for non-object input (boolean)
-  it('16. should throw a TypeError if input is a boolean', () => {
+  // Test case 15: Throw error for non-object input (boolean)
+  it('15. should throw a TypeError if input is a boolean', () => {
     expect(() =>
       fromDotNotation(true as unknown as Record<string, unknown>),
     ).toThrow(TypeError);
   });
 
-  // Test case 17: Throw error for null input
-  it('17. should throw a TypeError if input is null', () => {
+  // Test case 16: Throw error for null input
+  it('16. should throw a TypeError if input is null', () => {
     expect(() =>
       fromDotNotation(null as unknown as Record<string, unknown>),
     ).toThrow(TypeError);
   });
 
-  // Test case 18: Throw error for undefined input
-  it('18. should throw a TypeError if input is undefined', () => {
+  // Test case 17: Throw error for undefined input
+  it('17. should throw a TypeError if input is undefined', () => {
     expect(() =>
       fromDotNotation(undefined as unknown as Record<string, unknown>),
     ).toThrow(TypeError);

--- a/functionsUnittests/objectFunctions/isDeepSubset.test.ts
+++ b/functionsUnittests/objectFunctions/isDeepSubset.test.ts
@@ -147,6 +147,7 @@ describe('isDeepSubset', () => {
   });
 
   // Error-handling test cases
+
   // Test case 19: Handle non-object subset
   it('19. should throw a TypeError if subset is not an object', () => {
     expect(() =>

--- a/functionsUnittests/objectFunctions/queryStringToObject.test.ts
+++ b/functionsUnittests/objectFunctions/queryStringToObject.test.ts
@@ -44,48 +44,48 @@ describe('queryStringToObject', () => {
     expect(result).toEqual(expected);
   });
 
-  it('5. should preserve additional equals signs in parameter values', () => {
+  it('4. should preserve additional equals signs in parameter values', () => {
     const queryString = 'token=a=b=c&empty=&flag';
     const result = queryStringToObject(queryString);
     expect(result).toEqual({ token: 'a=b=c', empty: '', flag: '' });
   });
 
-  it('6. should decode encoded equals signs inside parameter values', () => {
+  it('4. should decode encoded equals signs inside parameter values', () => {
     const queryString = 'note=foo%3Dbar%3Dbaz&data=hello%3Dworld';
     const result = queryStringToObject(queryString);
     expect(result).toEqual({ note: 'foo=bar=baz', data: 'hello=world' });
   });
 
   // Test case 5: Handle non-string input (number)
-  it('7. should throw a TypeError if input is a number', () => {
+  it('5. should throw a TypeError if input is a number', () => {
     expect(() => queryStringToObject(42 as unknown as string)).toThrow(
       TypeError,
     );
   });
 
   // Test case 6: Handle non-string input (object)
-  it('8. should throw a TypeError if input is an object', () => {
+  it('6. should throw a TypeError if input is an object', () => {
     expect(() => queryStringToObject({} as unknown as string)).toThrow(
       TypeError,
     );
   });
 
   // Test case 7: Handle non-string input (boolean)
-  it('9. should throw a TypeError if input is a boolean', () => {
+  it('7. should throw a TypeError if input is a boolean', () => {
     expect(() => queryStringToObject(true as unknown as string)).toThrow(
       TypeError,
     );
   });
 
   // Test case 8: Handle non-string input (null)
-  it('10. should throw a TypeError if input is null', () => {
+  it('8. should throw a TypeError if input is null', () => {
     expect(() => queryStringToObject(null as unknown as string)).toThrow(
       TypeError,
     );
   });
 
   // Test case 9: Handle non-string input (undefined)
-  it('11. should throw a TypeError if input is undefined', () => {
+  it('9. should throw a TypeError if input is undefined', () => {
     expect(() => queryStringToObject(undefined as unknown as string)).toThrow(
       TypeError,
     );

--- a/functionsUnittests/stringFunctions/generateRandomString.test.ts
+++ b/functionsUnittests/stringFunctions/generateRandomString.test.ts
@@ -44,37 +44,8 @@ describe('generateRandomString', () => {
     expect(result).toMatch(new RegExp(`^[${charset}]+$`));
   });
 
-  // Test case 5: Generate a random string with non-numeric length
-  it('5. should throw an error when length is non-numeric', () => {
-    const charset: string =
-      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    expect(() =>
-      // Cast to match the function signature intentionally with invalid input
-      generateRandomString('a' as unknown as number, charset),
-    ).toThrow('Length must be a non-negative number');
-  });
-
-  // Test case 6: Generate a random string with negative length
-  it('6. should throw an error when length is negative', () => {
-    const length: number = -1;
-    const charset: string =
-      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    expect(() => generateRandomString(length, charset)).toThrow(
-      'Length must be a non-negative number',
-    );
-  });
-
-  // Test case 7: Generate a random string with an empty charset
-  it('7. should throw an error when charset is empty', () => {
-    const length: number = 10;
-    const charset: string = '';
-    expect(() => generateRandomString(length, charset)).toThrow(
-      'Charset must contain at least one character',
-    );
-  });
-
-  // Test case 8: Generate a random string with a single character charset
-  it('8. should generate a string of repeated characters when charset has a single character', () => {
+  // Test case 5: Generate a random string with a single character charset
+  it('5. should generate a string of repeated characters when charset has a single character', () => {
     const length: number = 10;
     const charset: string = 'A';
     const expected: string = 'A'.repeat(length);
@@ -82,8 +53,8 @@ describe('generateRandomString', () => {
     expect(result).toBe(expected);
   });
 
-  // Test case 9: Generate a random string with special characters in charset
-  it('9. should generate a random string with special characters in charset', () => {
+  // Test case 6: Generate a random string with special characters in charset
+  it('6. should generate a random string with special characters in charset', () => {
     const length: number = 10;
     const charset: string = '!@#$%^&*()';
     const result: string = generateRandomString(length, charset);
@@ -93,12 +64,42 @@ describe('generateRandomString', () => {
     );
   });
 
-  // Test case 10: Generate a random string with numeric characters in charset
-  it('10. should generate a random string with numeric characters in charset', () => {
+  // Test case 7: Generate a random string with numeric characters in charset
+  it('7. should generate a random string with numeric characters in charset', () => {
     const length: number = 10;
     const charset: string = '0123456789';
     const result: string = generateRandomString(length, charset);
     expect(result).toHaveLength(length);
     expect(result).toMatch(new RegExp(`^[${charset}]+$`));
   });
+
+  // Test case 8: Generate a random string with non-numeric length
+  it('8. should throw an error when length is non-numeric', () => {
+    const charset: string =
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    expect(() =>
+      // Cast to match the function signature intentionally with invalid input
+      generateRandomString('a' as unknown as number, charset),
+    ).toThrow('Length must be a non-negative number');
+  });
+
+  // Test case 9: Generate a random string with negative length
+  it('9. should throw an error when length is negative', () => {
+    const length: number = -1;
+    const charset: string =
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    expect(() => generateRandomString(length, charset)).toThrow(
+      'Length must be a non-negative number',
+    );
+  });
+
+  // Test case 10: Generate a random string with an empty charset
+  it('10. should throw an error when charset is empty', () => {
+    const length: number = 10;
+    const charset: string = '';
+    expect(() => generateRandomString(length, charset)).toThrow(
+      'Charset must contain at least one character',
+    );
+  });
+
 });

--- a/functionsUnittests/stringFunctions/padString.test.ts
+++ b/functionsUnittests/stringFunctions/padString.test.ts
@@ -127,7 +127,7 @@ describe('padString', () => {
   });
 
   // Error handling test case 1: Target length less than string length
-  it('14. should throw an error when target length is less than string length', () => {
+  it('13. should throw an error when target length is less than string length', () => {
     const str: string = 'hello';
     const targetLength: number = 3;
     expect(() => padString(str, targetLength)).toThrow(
@@ -136,7 +136,7 @@ describe('padString', () => {
   });
 
   // Error handling test case 2: Pad character is not a single character
-  it('15. should throw an error when pad character is not a single character', () => {
+  it('13. should throw an error when pad character is not a single character', () => {
     const str: string = 'hello';
     const targetLength: number = 10;
     const padChar: string = '**';

--- a/functionsUnittests/stringFunctions/repeatString.test.ts
+++ b/functionsUnittests/stringFunctions/repeatString.test.ts
@@ -122,7 +122,7 @@ describe('repeatString', () => {
   });
 
   // Error handling test case 1: Repeat a string with a negative count
-  it('14. should throw an error when repeating a string with a negative count', () => {
+  it('13. should throw an error when repeating a string with a negative count', () => {
     const str: string = 'hello';
     const count: number = -1;
     expect(() => repeatString(str, count)).toThrow(
@@ -131,7 +131,7 @@ describe('repeatString', () => {
   });
 
   // Error handling test case 2: Repeat a string with a non-numeric count
-  it('15. should throw an error when repeating a string with a non-numeric count', () => {
+  it('13. should throw an error when repeating a string with a non-numeric count', () => {
     const str: string = 'hello';
     expect(() => repeatString(str, 'a' as unknown as number)).toThrow(
       'Count must be a number',

--- a/functionsUnittests/stringFunctions/repeatUntilLength.test.ts
+++ b/functionsUnittests/stringFunctions/repeatUntilLength.test.ts
@@ -122,7 +122,7 @@ describe('repeatUntilLength', () => {
   });
 
   // Error handling test case 1: Repeat a string with a negative length
-  it('14. should throw an error when repeating a string with a negative length', () => {
+  it('13. should throw an error when repeating a string with a negative length', () => {
     const str: string = 'hello';
     const length: number = -1;
     expect(() => repeatUntilLength(str, length)).toThrow(
@@ -131,7 +131,7 @@ describe('repeatUntilLength', () => {
   });
 
   // Error handling test case 2: Repeat a string with a non-numeric length
-  it('15. should throw an error when repeating a string with a non-numeric length', () => {
+  it('13. should throw an error when repeating a string with a non-numeric length', () => {
     const str: string = 'hello';
     expect(() => repeatUntilLength(str, 'a' as unknown as number)).toThrow(
       'Length must be a number',

--- a/functionsUnittests/utilityFunctions/debounceAsync.test.ts
+++ b/functionsUnittests/utilityFunctions/debounceAsync.test.ts
@@ -39,8 +39,17 @@ describe('debounceAsync', () => {
     await expect(promise).resolves.toBe(3);
   });
 
-  // Test case 4: Propagate rejection
-  it('4. should propagate rejection from the underlying function', async () => {
+  // Test case 4: Work with zero wait time
+  it('4. should work with zero wait time', async () => {
+    const fn = jest.fn(() => Promise.resolve('done'));
+    const debounced = debounceAsync(fn, 0);
+    const promise = debounced();
+    jest.runAllTimers();
+    await expect(promise).resolves.toBe('done');
+  });
+
+  // Test case 5: Propagate rejection
+  it('5. should propagate rejection from the underlying function', async () => {
     const fn = jest.fn(() => Promise.reject(new Error('Test error')));
     const debounced = debounceAsync(fn, 50);
     const promise = debounced();
@@ -48,12 +57,4 @@ describe('debounceAsync', () => {
     await expect(promise).rejects.toThrow('Test error');
   });
 
-  // Test case 5: Work with zero wait time
-  it('5. should work with zero wait time', async () => {
-    const fn = jest.fn(() => Promise.resolve('done'));
-    const debounced = debounceAsync(fn, 0);
-    const promise = debounced();
-    jest.runAllTimers();
-    await expect(promise).resolves.toBe('done');
-  });
 });

--- a/functionsUnittests/utilityFunctions/throttle.test.ts
+++ b/functionsUnittests/utilityFunctions/throttle.test.ts
@@ -20,8 +20,8 @@ describe('throttle', () => {
     }, 40);
   });
 
-  // Test case 2: Ensure the function is only called once within the limit
-  it('2. should throttle rapid successive calls', (done) => {
+  // Test case 1: Ensure the function is only called once within the limit
+  it('1. should throttle rapid successive calls', (done) => {
     const mockFn = jest.fn();
     const throttled = throttle(mockFn, 30);
 
@@ -39,8 +39,8 @@ describe('throttle', () => {
     }, 50);
   });
 
-  // Test case 3: Verify arguments from the last call are used
-  it('3. should use the latest arguments for the delayed call', (done) => {
+  // Test case 2: Verify arguments from the last call are used
+  it('2. should use the latest arguments for the delayed call', (done) => {
     const received: number[] = [];
     const throttled = throttle((val: number) => received.push(val), 20);
 
@@ -53,8 +53,8 @@ describe('throttle', () => {
     }, 40);
   });
 
-  // Test case 4: Allow calls after the wait period has passed
-  it('4. should execute again after the limit when called later', (done) => {
+  // Test case 3: Allow calls after the wait period has passed
+  it('3. should execute again after the limit when called later', (done) => {
     const mockFn = jest.fn();
     const throttled = throttle(mockFn, 20);
 
@@ -70,7 +70,7 @@ describe('throttle', () => {
     }, 60);
   });
 
-  it('5. should throttle immediately after a trailing execution', (done) => {
+  it('3. should throttle immediately after a trailing execution', (done) => {
     const mockFn = jest.fn();
     const throttled = throttle(mockFn, 30);
 

--- a/functionsUnittests/validationFunctionsUnittest/isInRange.test.ts
+++ b/functionsUnittests/validationFunctionsUnittest/isInRange.test.ts
@@ -30,8 +30,27 @@ describe('isInRange', () => {
     expect(isInRange(9.9, 1, 10, false)).toBe(true);
   });
 
-  // Test case 4: TypeError for invalid input types
-  it('4. should throw TypeError for invalid input types', () => {
+  // Test case 4: Performance with various ranges
+  it('4. should validate ranges efficiently', () => {
+    const tests = [
+      { value: 5, min: 1, max: 10, inclusive: true },
+      { value: 1, min: 1, max: 10, inclusive: false },
+      { value: 3.14, min: 3, max: 4, inclusive: true },
+      { value: 0, min: 1, max: 10, inclusive: true },
+    ];
+
+    const startTime = performance.now();
+    const results = tests.map((test) =>
+      isInRange(test.value, test.min, test.max, test.inclusive),
+    );
+    const endTime = performance.now();
+
+    expect(results).toEqual([true, false, true, false]);
+    expect(endTime - startTime).toBeLessThan(10);
+  });
+
+  // Test case 5: TypeError for invalid input types
+  it('5. should throw TypeError for invalid input types', () => {
     const invalidInputs = ['string', null, undefined, [], {}, true];
 
     invalidInputs.forEach((input) => {
@@ -51,37 +70,19 @@ describe('isInRange', () => {
     );
   });
 
-  // Test case 5: Error for NaN values
-  it('5. should throw Error for NaN values', () => {
+  // Test case 6: Error for NaN values
+  it('6. should throw Error for NaN values', () => {
     expect(() => isInRange(NaN, 1, 10)).toThrow(Error);
     expect(() => isInRange(5, NaN, 10)).toThrow(Error);
     expect(() => isInRange(5, 1, NaN)).toThrow(Error);
   });
 
-  // Test case 6: Error for min > max
-  it('6. should throw Error when min is greater than max', () => {
+  // Test case 7: Error for min > max
+  it('7. should throw Error when min is greater than max', () => {
     expect(() => isInRange(5, 10, 1)).toThrow(Error);
     expect(() => isInRange(5, 10, 1)).toThrow(
       'min (10) must be less than or equal to max (1)',
     );
   });
 
-  // Test case 7: Performance with various ranges
-  it('7. should validate ranges efficiently', () => {
-    const tests = [
-      { value: 5, min: 1, max: 10, inclusive: true },
-      { value: 1, min: 1, max: 10, inclusive: false },
-      { value: 3.14, min: 3, max: 4, inclusive: true },
-      { value: 0, min: 1, max: 10, inclusive: true },
-    ];
-
-    const startTime = performance.now();
-    const results = tests.map((test) =>
-      isInRange(test.value, test.min, test.max, test.inclusive),
-    );
-    const endTime = performance.now();
-
-    expect(results).toEqual([true, false, true, false]);
-    expect(endTime - startTime).toBeLessThan(10);
-  });
 });

--- a/functionsUnittests/validationFunctionsUnittest/isValidIPv4.test.ts
+++ b/functionsUnittests/validationFunctionsUnittest/isValidIPv4.test.ts
@@ -35,19 +35,8 @@ describe('isValidIPv4', () => {
     expect(isValidIPv4('0.0.0.1')).toBe(true); // Mixed min/small
   });
 
-  // Test case 4: TypeError for invalid input type
-  it('4. should throw TypeError for non-string input', () => {
-    // Arrange
-    const invalidInputs: unknown[] = [null, undefined, 42, {}, [], true];
-
-    // Act & Assert
-    for (const input of invalidInputs) {
-      expect(() => isValidIPv4(input as string)).toThrow(TypeError);
-    }
-  });
-
-  // Test case 5: Leading zeros validation
-  it('5. should reject IPv4 addresses with leading zeros', () => {
+  // Test case 4: Leading zeros validation
+  it('4. should reject IPv4 addresses with leading zeros', () => {
     // Arrange & Act & Assert
     expect(isValidIPv4('192.168.01.1')).toBe(false);
     expect(isValidIPv4('192.168.001.1')).toBe(false);
@@ -59,8 +48,8 @@ describe('isValidIPv4', () => {
     expect(isValidIPv4('0.0.0.0')).toBe(true);
   });
 
-  // Test case 6: Performance with various IP addresses
-  it('6. should validate IP addresses efficiently', () => {
+  // Test case 5: Performance with various IP addresses
+  it('5. should validate IP addresses efficiently', () => {
     // Arrange
     const ipAddresses = [
       '192.168.1.1',
@@ -79,4 +68,16 @@ describe('isValidIPv4', () => {
     expect(results).toEqual([true, true, true, false, false]);
     expect(endTime - startTime).toBeLessThan(10); // Should complete quickly
   });
+
+  // Test case 6: TypeError for invalid input type
+  it('6. should throw TypeError for non-string input', () => {
+    // Arrange
+    const invalidInputs: unknown[] = [null, undefined, 42, {}, [], true];
+
+    // Act & Assert
+    for (const input of invalidInputs) {
+      expect(() => isValidIPv4(input as string)).toThrow(TypeError);
+    }
+  });
+
 });

--- a/functionsUnittests/validationFunctionsUnittest/isValidIPv6.test.ts
+++ b/functionsUnittests/validationFunctionsUnittest/isValidIPv6.test.ts
@@ -37,23 +37,8 @@ describe('isValidIPv6', () => {
     expect(isValidIPv6('fe80::1%invalid::zone')).toBe(false); // Invalid zone
   });
 
-  // Test case 4: TypeError for invalid input type
-  it('4. should throw TypeError for non-string input', () => {
-    // Arrange
-    const invalidInputs = [123, null, undefined, [], {}, true];
-    const expectedMessage = 'ip must be a string, got';
-
-    // Act & Assert
-    invalidInputs.forEach((input) => {
-      expect(() => isValidIPv6(input as unknown as string)).toThrow(TypeError);
-      expect(() => isValidIPv6(input as unknown as string)).toThrow(
-        expectedMessage,
-      );
-    });
-  });
-
-  // Test case 5: Compression edge cases
-  it('5. should handle compression edge cases correctly', () => {
+  // Test case 4: Compression edge cases
+  it('4. should handle compression edge cases correctly', () => {
     // Arrange & Act & Assert
     expect(isValidIPv6('2001:db8::')).toBe(true); // Compression at end
     expect(isValidIPv6('::2001:db8')).toBe(true); // Compression at start
@@ -65,8 +50,8 @@ describe('isValidIPv6', () => {
     expect(isValidIPv6('2001::db8::1')).toBe(false); // Multiple compressions
   });
 
-  // Test case 6: Performance with various IPv6 addresses
-  it('6. should validate IPv6 addresses efficiently', () => {
+  // Test case 5: Performance with various IPv6 addresses
+  it('5. should validate IPv6 addresses efficiently', () => {
     // Arrange
     const ipv6Addresses = [
       '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
@@ -85,4 +70,20 @@ describe('isValidIPv6', () => {
     expect(results).toEqual([true, true, true, true, false]);
     expect(endTime - startTime).toBeLessThan(10); // Should complete quickly
   });
+
+  // Test case 6: TypeError for invalid input type
+  it('6. should throw TypeError for non-string input', () => {
+    // Arrange
+    const invalidInputs = [123, null, undefined, [], {}, true];
+    const expectedMessage = 'ip must be a string, got';
+
+    // Act & Assert
+    invalidInputs.forEach((input) => {
+      expect(() => isValidIPv6(input as unknown as string)).toThrow(TypeError);
+      expect(() => isValidIPv6(input as unknown as string)).toThrow(
+        expectedMessage,
+      );
+    });
+  });
+
 });

--- a/functionsUnittests/validationFunctionsUnittest/isValidISODate.test.ts
+++ b/functionsUnittests/validationFunctionsUnittest/isValidISODate.test.ts
@@ -32,31 +32,16 @@ describe('isValidISODate', () => {
     expect(isValidISODate('2023-12-25', true)).toBe(true);
   });
 
-  // Test case 4: TypeError for invalid input types
-  it('4. should throw TypeError for invalid input types', () => {
-    const invalidInputs = [123, null, undefined, [], {}, true];
-
-    invalidInputs.forEach((input) => {
-      expect(() => isValidISODate(input as unknown as string)).toThrow(
-        TypeError,
-      );
-    });
-
-    expect(() =>
-      isValidISODate('2023-12-25', 'invalid' as unknown as boolean),
-    ).toThrow(TypeError);
-  });
-
-  // Test case 5: Edge cases and boundary values
-  it('5. should handle edge cases correctly', () => {
+  // Test case 4: Edge cases and boundary values
+  it('4. should handle edge cases correctly', () => {
     expect(isValidISODate('1900-01-01')).toBe(true);
     expect(isValidISODate('2100-12-31')).toBe(true);
     expect(isValidISODate('2023-01-01T00:00:00Z')).toBe(true);
     expect(isValidISODate('2023-12-31T23:59:59Z')).toBe(true);
   });
 
-  // Test case 6: Performance with various date strings
-  it('6. should validate dates efficiently', () => {
+  // Test case 5: Performance with various date strings
+  it('5. should validate dates efficiently', () => {
     const dateStrings = [
       '2023-12-25',
       '2023-12-25T10:30:00Z',
@@ -72,4 +57,20 @@ describe('isValidISODate', () => {
     expect(results).toEqual([true, true, false, false, true]);
     expect(endTime - startTime).toBeLessThan(10);
   });
+
+  // Test case 6: TypeError for invalid input types
+  it('6. should throw TypeError for invalid input types', () => {
+    const invalidInputs = [123, null, undefined, [], {}, true];
+
+    invalidInputs.forEach((input) => {
+      expect(() => isValidISODate(input as unknown as string)).toThrow(
+        TypeError,
+      );
+    });
+
+    expect(() =>
+      isValidISODate('2023-12-25', 'invalid' as unknown as boolean),
+    ).toThrow(TypeError);
+  });
+
 });

--- a/functionsUnittests/validationFunctionsUnittest/isValidJSON.test.ts
+++ b/functionsUnittests/validationFunctionsUnittest/isValidJSON.test.ts
@@ -26,20 +26,8 @@ describe('isValidJSON', () => {
     expect(isValidJSON('}')).toBe(false);
   });
 
-  // Test case 3: TypeError for invalid input types
-  it('3. should throw TypeError for invalid input types', () => {
-    const invalidInputs = [123, null, undefined, [], {}, true];
-
-    invalidInputs.forEach((input) => {
-      expect(() => isValidJSON(input as unknown as string)).toThrow(TypeError);
-      expect(() => isValidJSON(input as unknown as string)).toThrow(
-        'jsonString must be a string, got',
-      );
-    });
-  });
-
-  // Test case 4: Performance with various JSON strings
-  it('4. should validate JSON strings efficiently', () => {
+  // Test case 3: Performance with various JSON strings
+  it('3. should validate JSON strings efficiently', () => {
     const jsonStrings = [
       '{"valid": true}',
       '["array", "of", "strings"]',
@@ -55,4 +43,17 @@ describe('isValidJSON', () => {
     expect(results).toEqual([true, true, false, true, true]);
     expect(endTime - startTime).toBeLessThan(10);
   });
+
+  // Test case 4: TypeError for invalid input types
+  it('4. should throw TypeError for invalid input types', () => {
+    const invalidInputs = [123, null, undefined, [], {}, true];
+
+    invalidInputs.forEach((input) => {
+      expect(() => isValidJSON(input as unknown as string)).toThrow(TypeError);
+      expect(() => isValidJSON(input as unknown as string)).toThrow(
+        'jsonString must be a string, got',
+      );
+    });
+  });
+
 });

--- a/functionsUnittests/validationFunctionsUnittest/isValidMACAddress.test.ts
+++ b/functionsUnittests/validationFunctionsUnittest/isValidMACAddress.test.ts
@@ -33,42 +33,8 @@ describe('isValidMACAddress', () => {
     expect(isValidMACAddress('00:1B:44:11:3A:B')).toBe(false); // Incomplete last group
   });
 
-  // Test case 4: TypeError for invalid input types
-  it('4. should throw TypeError for invalid input types', () => {
-    // Arrange & Act & Assert
-    expect(() => isValidMACAddress(123 as unknown as string)).toThrow(
-      TypeError,
-    );
-    expect(() =>
-      isValidMACAddress('00:1B:44:11:3A:B7', 123 as unknown as string),
-    ).toThrow(TypeError);
-
-    const expectedMacMessage = 'mac must be a string, got number';
-    const expectedSeparatorMessage = 'separator must be a string, got number';
-
-    expect(() => isValidMACAddress(123 as unknown as string)).toThrow(
-      expectedMacMessage,
-    );
-    expect(() =>
-      isValidMACAddress('00:1B:44:11:3A:B7', 123 as unknown as string),
-    ).toThrow(expectedSeparatorMessage);
-  });
-
-  // Test case 5: Error for invalid separator length
-  it('5. should throw Error for multi-character separator', () => {
-    // Arrange
-    const expectedMessage = 'separator must be a single character, got "ab"';
-
-    // Act & Assert
-    expect(() => isValidMACAddress('00:1B:44:11:3A:B7', 'ab')).toThrow(Error);
-    expect(() => isValidMACAddress('00:1B:44:11:3A:B7', 'ab')).toThrow(
-      expectedMessage,
-    );
-    expect(() => isValidMACAddress('00:1B:44:11:3A:B7', '::')).toThrow(Error);
-  });
-
-  // Test case 6: Performance with various MAC addresses
-  it('6. should validate MAC addresses efficiently', () => {
+  // Test case 4: Performance with various MAC addresses
+  it('4. should validate MAC addresses efficiently', () => {
     // Arrange
     const macAddresses = [
       '00:1B:44:11:3A:B7',
@@ -90,4 +56,39 @@ describe('isValidMACAddress', () => {
     expect(results).toEqual([true, true, true, false, false]);
     expect(endTime - startTime).toBeLessThan(10); // Should complete quickly
   });
+
+  // Test case 5: TypeError for invalid input types
+  it('5. should throw TypeError for invalid input types', () => {
+    // Arrange & Act & Assert
+    expect(() => isValidMACAddress(123 as unknown as string)).toThrow(
+      TypeError,
+    );
+    expect(() =>
+      isValidMACAddress('00:1B:44:11:3A:B7', 123 as unknown as string),
+    ).toThrow(TypeError);
+
+    const expectedMacMessage = 'mac must be a string, got number';
+    const expectedSeparatorMessage = 'separator must be a string, got number';
+
+    expect(() => isValidMACAddress(123 as unknown as string)).toThrow(
+      expectedMacMessage,
+    );
+    expect(() =>
+      isValidMACAddress('00:1B:44:11:3A:B7', 123 as unknown as string),
+    ).toThrow(expectedSeparatorMessage);
+  });
+
+  // Test case 6: Error for invalid separator length
+  it('6. should throw Error for multi-character separator', () => {
+    // Arrange
+    const expectedMessage = 'separator must be a single character, got "ab"';
+
+    // Act & Assert
+    expect(() => isValidMACAddress('00:1B:44:11:3A:B7', 'ab')).toThrow(Error);
+    expect(() => isValidMACAddress('00:1B:44:11:3A:B7', 'ab')).toThrow(
+      expectedMessage,
+    );
+    expect(() => isValidMACAddress('00:1B:44:11:3A:B7', '::')).toThrow(Error);
+  });
+
 });

--- a/functionsUnittests/validationFunctionsUnittest/isValidPattern.test.ts
+++ b/functionsUnittests/validationFunctionsUnittest/isValidPattern.test.ts
@@ -35,37 +35,8 @@ describe('isValidPattern', () => {
     expect(isValidPattern('Hello\nWorld', 'hello.*world', 'is')).toBe(true);
   });
 
-  // Test case 4: TypeError for invalid input types
-  it('4. should throw TypeError for invalid input types', () => {
-    const invalidInputs = [123, null, undefined, [], {}, true];
-
-    invalidInputs.forEach((input) => {
-      expect(() =>
-        isValidPattern(input as unknown as string, '[A-Z]+'),
-      ).toThrow(TypeError);
-      expect(() => isValidPattern('test', input as unknown as string)).toThrow(
-        TypeError,
-      );
-      expect(() =>
-        isValidPattern('test', '[A-Z]+', input as unknown as string),
-      ).toThrow(TypeError);
-    });
-  });
-
-  // Test case 5: Error for invalid regex patterns
-  it('5. should throw Error for invalid regex patterns', () => {
-    const invalidPatterns = ['[', ')', '*', '+{', '(?'];
-
-    invalidPatterns.forEach((pattern) => {
-      expect(() => isValidPattern('test', pattern)).toThrow(Error);
-      expect(() => isValidPattern('test', pattern)).toThrow(
-        'Invalid regular expression pattern',
-      );
-    });
-  });
-
-  // Test case 6: Performance with various patterns
-  it('6. should validate patterns efficiently', () => {
+  // Test case 4: Performance with various patterns
+  it('4. should validate patterns efficiently', () => {
     const tests = [
       { input: 'ABC123', pattern: '[A-Z]{3}[0-9]{3}' },
       { input: 'test@example.com', pattern: '^[^@]+@[^@]+\\.[^@]+$' },
@@ -82,4 +53,34 @@ describe('isValidPattern', () => {
     expect(results).toEqual([true, true, false, true]);
     expect(endTime - startTime).toBeLessThan(10);
   });
+
+  // Test case 5: TypeError for invalid input types
+  it('5. should throw TypeError for invalid input types', () => {
+    const invalidInputs = [123, null, undefined, [], {}, true];
+
+    invalidInputs.forEach((input) => {
+      expect(() =>
+        isValidPattern(input as unknown as string, '[A-Z]+'),
+      ).toThrow(TypeError);
+      expect(() => isValidPattern('test', input as unknown as string)).toThrow(
+        TypeError,
+      );
+      expect(() =>
+        isValidPattern('test', '[A-Z]+', input as unknown as string),
+      ).toThrow(TypeError);
+    });
+  });
+
+  // Test case 6: Error for invalid regex patterns
+  it('6. should throw Error for invalid regex patterns', () => {
+    const invalidPatterns = ['[', ')', '*', '+{', '(?'];
+
+    invalidPatterns.forEach((pattern) => {
+      expect(() => isValidPattern('test', pattern)).toThrow(Error);
+      expect(() => isValidPattern('test', pattern)).toThrow(
+        'Invalid regular expression pattern',
+      );
+    });
+  });
+
 });

--- a/functionsUnittests/validationFunctionsUnittest/isValidTime.test.ts
+++ b/functionsUnittests/validationFunctionsUnittest/isValidTime.test.ts
@@ -40,17 +40,8 @@ describe('isValidTime', () => {
     expect(isValidTime('12:60 PM', true, false)).toBe(false);
   });
 
-  // Test case 5: TypeError for invalid input types
-  it('5. should throw TypeError for invalid input types', () => {
-    const invalidInputs = [123, null, undefined, [], {}, true];
-
-    invalidInputs.forEach((input) => {
-      expect(() => isValidTime(input as unknown as string)).toThrow(TypeError);
-    });
-  });
-
-  // Test case 6: Performance with various time strings
-  it('6. should validate time strings efficiently', () => {
+  // Test case 5: Performance with various time strings
+  it('5. should validate time strings efficiently', () => {
     const timeStrings = ['14:30', '25:00', '2:30 PM', '12:30:45 AM', 'invalid'];
 
     const startTime = performance.now();
@@ -65,4 +56,14 @@ describe('isValidTime', () => {
     expect(results).toEqual([true, false, true, true, false]);
     expect(endTime - startTime).toBeLessThan(10);
   });
+
+  // Test case 6: TypeError for invalid input types
+  it('6. should throw TypeError for invalid input types', () => {
+    const invalidInputs = [123, null, undefined, [], {}, true];
+
+    invalidInputs.forEach((input) => {
+      expect(() => isValidTime(input as unknown as string)).toThrow(TypeError);
+    });
+  });
+
 });

--- a/functionsUnittests/validationFunctionsUnittest/isValidUUID.test.ts
+++ b/functionsUnittests/validationFunctionsUnittest/isValidUUID.test.ts
@@ -38,8 +38,29 @@ describe('isValidUUID', () => {
     expect(isValidUUID('550e8400-e29b-41d4-a716-446655440000', 1)).toBe(false);
   });
 
-  // Test case 4: TypeError for invalid input types
-  it('4. should throw TypeError for invalid input types', () => {
+  // Test case 4: Performance with various UUIDs
+  it('4. should validate UUIDs efficiently', () => {
+    // Arrange
+    const uuids = [
+      '123e4567-e89b-12d3-a456-426614174000',
+      '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+      'invalid-uuid',
+      '550e8400-e29b-41d4-a716-446655440000',
+      '123e4567-e89b-12d3-a456-42661417400',
+    ];
+
+    // Act
+    const startTime = performance.now();
+    const results = uuids.map((uuid) => isValidUUID(uuid));
+    const endTime = performance.now();
+
+    // Assert
+    expect(results).toEqual([true, true, false, true, false]);
+    expect(endTime - startTime).toBeLessThan(10); // Should complete quickly
+  });
+
+  // Test case 5: TypeError for invalid input types
+  it('5. should throw TypeError for invalid input types', () => {
     // Arrange
     const invalidInputs: unknown[] = [null, undefined, 42, {}, [], true];
     const expectedMessage = 'uuid must be a string, got';
@@ -65,8 +86,8 @@ describe('isValidUUID', () => {
     ).toThrow('version must be a number, got');
   });
 
-  // Test case 5: Error for unsupported version
-  it('5. should throw Error for unsupported UUID version', () => {
+  // Test case 6: Error for unsupported version
+  it('6. should throw Error for unsupported UUID version', () => {
     // Arrange
     const validUUID = '123e4567-e89b-12d3-a456-426614174000';
     const unsupportedVersions = [0, 2, 6, 7, -1, 10];
@@ -80,24 +101,4 @@ describe('isValidUUID', () => {
     });
   });
 
-  // Test case 6: Performance with various UUIDs
-  it('6. should validate UUIDs efficiently', () => {
-    // Arrange
-    const uuids = [
-      '123e4567-e89b-12d3-a456-426614174000',
-      '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
-      'invalid-uuid',
-      '550e8400-e29b-41d4-a716-446655440000',
-      '123e4567-e89b-12d3-a456-42661417400',
-    ];
-
-    // Act
-    const startTime = performance.now();
-    const results = uuids.map((uuid) => isValidUUID(uuid));
-    const endTime = performance.now();
-
-    // Assert
-    expect(results).toEqual([true, true, false, true, false]);
-    expect(endTime - startTime).toBeLessThan(10); // Should complete quickly
-  });
 });

--- a/scripts/reorderTests.js
+++ b/scripts/reorderTests.js
@@ -1,0 +1,110 @@
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', 'functionsUnittests');
+
+function getTestFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...getTestFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.test.ts')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function splitSuffix(lines) {
+  let index = lines.length - 1;
+  while (index >= 0 && lines[index].trim() === '') {
+    index -= 1;
+  }
+  if (index >= 0 && lines[index].trim() === '});') {
+    return {
+      workingLines: lines.slice(0, index),
+      suffixLines: lines.slice(index),
+    };
+  }
+  return { workingLines: lines.slice(), suffixLines: [] };
+}
+
+function updateNumbering(lines, newNumber) {
+  const numberString = String(newNumber);
+  return lines.map((line) => {
+    if (line.trim().startsWith('// Test case ')) {
+      return line.replace(/(\/\/ Test case )\d+/, `$1${numberString}`);
+    }
+    return line.replace(/((?:it|test)\(\s*['"`])\d+(\.)/, `$1${numberString}$2`);
+  });
+}
+
+function processFile(filePath) {
+  const originalContent = fs.readFileSync(filePath, 'utf8');
+  const lines = originalContent.split('\n');
+  const { workingLines, suffixLines } = splitSuffix(lines);
+
+  const blocks = [];
+  let i = 0;
+  while (i < workingLines.length) {
+    if (workingLines[i].trim().startsWith('// Test case ')) {
+      const start = i;
+      let end = i + 1;
+      while (end < workingLines.length && !workingLines[end].trim().startsWith('// Test case ')) {
+        end += 1;
+      }
+      const blockLines = workingLines.slice(start, end);
+      const hasToThrow = blockLines.some((line) => line.includes('toThrow'));
+      blocks.push({ start, end, lines: blockLines, hasToThrow });
+      i = end;
+    } else {
+      i += 1;
+    }
+  }
+
+  if (blocks.length === 0) {
+    return false;
+  }
+
+  const prefixLines = workingLines.slice(0, blocks[0].start);
+  const betweenSuffixLines = workingLines.slice(blocks[blocks.length - 1].end);
+  const nonErrorBlocks = blocks.filter((block) => !block.hasToThrow);
+  const errorBlocks = blocks.filter((block) => block.hasToThrow);
+  const orderedBlocks = [...nonErrorBlocks, ...errorBlocks];
+
+  const newLines = [...prefixLines];
+  orderedBlocks.forEach((block, index) => {
+    if (
+      index > 0 &&
+      newLines.length > 0 &&
+      newLines[newLines.length - 1].trim() !== ''
+    ) {
+      newLines.push('');
+    }
+    const updated = updateNumbering(block.lines, index + 1);
+    newLines.push(...updated);
+  });
+  newLines.push(...betweenSuffixLines);
+  newLines.push(...suffixLines);
+
+  const newContent = newLines.join('\n');
+  if (newContent !== originalContent) {
+    fs.writeFileSync(filePath, newContent, 'utf8');
+    return true;
+  }
+  return false;
+}
+
+const files = getTestFiles(rootDir);
+let modifiedCount = 0;
+files.forEach((filePath) => {
+  const changed = processFile(filePath);
+  if (changed) {
+    modifiedCount += 1;
+  }
+});
+
+console.log(`Processed ${files.length} test files.`);
+console.log(`Modified ${modifiedCount} files.`);


### PR DESCRIPTION
## Summary
- add a script that normalizes unit test blocks and gathers the error-case checks at the end of each suite
- reorder existing unit tests so that error assertions appear after the non-error scenarios with updated numbering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e93b944ab883259591fbab4746430d