### PR TITLE
Add runtime validation to utility timers

### DIFF
--- a/utilityFunctions/debounce.ts
+++ b/utilityFunctions/debounce.ts
@@ -49,6 +49,16 @@ export function debounce<Args extends unknown[], R>(
   func: (...args: Args) => R,
   delay: number,
 ): (...args: Args) => void {
+  if (typeof func !== 'function') {
+    throw new TypeError(`func must be a function, got ${typeof func}`);
+  }
+  if (typeof delay !== 'number') {
+    throw new TypeError(`delay must be a number, got ${typeof delay}`);
+  }
+  if (Number.isNaN(delay) || delay < 0) {
+    throw new Error('delay must be a non-negative number');
+  }
+
   let timeoutId: ReturnType<typeof setTimeout>;
   return function (this: unknown, ...args: Args) {
     clearTimeout(timeoutId);

--- a/utilityFunctions/debounceAsync.ts
+++ b/utilityFunctions/debounceAsync.ts
@@ -7,6 +7,7 @@
  * @returns A debounced version of the function that returns a Promise.
  *
  * @throws {TypeError} If func is not a function or wait is not a number.
+ * @throws {Error} If wait is negative or NaN.
  *
  * @example
  * // Basic usage with API calls
@@ -49,6 +50,16 @@ export function debounceAsync<Args extends unknown[], R>(
   func: (...args: Args) => Promise<R>,
   wait: number,
 ): (...args: Args) => Promise<R> {
+  if (typeof func !== 'function') {
+    throw new TypeError(`func must be a function, got ${typeof func}`);
+  }
+  if (typeof wait !== 'number') {
+    throw new TypeError(`wait must be a number, got ${typeof wait}`);
+  }
+  if (Number.isNaN(wait) || wait < 0) {
+    throw new Error('wait must be a non-negative number');
+  }
+
   let timeoutId: ReturnType<typeof setTimeout>;
   return (...args: Args) =>
     new Promise((resolve) => {

--- a/utilityFunctions/delay.ts
+++ b/utilityFunctions/delay.ts
@@ -32,5 +32,12 @@
  * @complexity Time: O(1), Space: O(1)
  */
 export function delay(ms: number): Promise<void> {
+  if (typeof ms !== 'number') {
+    throw new TypeError(`ms must be a number, got ${typeof ms}`);
+  }
+  if (Number.isNaN(ms) || ms < 0) {
+    throw new Error('ms must be a non-negative number');
+  }
+
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/utilityFunctions/throttle.ts
+++ b/utilityFunctions/throttle.ts
@@ -52,6 +52,16 @@ export function throttle<Args extends unknown[]>(
   func: (...args: Args) => void,
   limit: number,
 ): (...args: Args) => void {
+  if (typeof func !== 'function') {
+    throw new TypeError(`func must be a function, got ${typeof func}`);
+  }
+  if (typeof limit !== 'number') {
+    throw new TypeError(`limit must be a number, got ${typeof limit}`);
+  }
+  if (Number.isNaN(limit) || limit < 0) {
+    throw new Error('limit must be a non-negative number');
+  }
+
   let lastFunc: NodeJS.Timeout | null;
   let lastRan: number | null = null;
   return function (this: unknown, ...args: Args) {


### PR DESCRIPTION
## Summary
- add runtime argument validation to debounce, debounceAsync, delay, and throttle to match documented expectations
- document debounceAsync error handling for invalid wait values

## Testing
- npx jest --config jest.local.config.ts --runInBand --runTestsByPath functionsUnittests/utilityFunctions/debounce.test.ts functionsUnittests/utilityFunctions/debounceAsync.test.ts functionsUnittests/utilityFunctions/delay.test.ts functionsUnittests/utilityFunctions/throttle.test.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1f75e14083258ba3bcf718ad78ff)